### PR TITLE
update: changes the youtube link on footer to the youtube channel for Beagle v1.7

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -157,6 +157,6 @@ enable = true
         desc = "Medium"
 [[params.links.developer]]
 	name ="Youtube"
-	url = "https://www.youtube.com/channel/UCJWZyJ-36yNscqnnHiwjkhQ"
+	url = "https://www.youtube.com/playlist?list=PLkX9oUrQ1ev7sU5idjF-jEfJIAL-j89wZ"
 	icon = "fab fa-youtube"
         desc = "Youtube"


### PR DESCRIPTION
changes the youtube link on footer to the youtube channel for Beagle on v1.7