### PR TITLE
fix: remove unnecessary link on beagle framework

### DIFF
--- a/content/en/resources/customization/beagle-for-backend/beagle-framework.md
+++ b/content/en/resources/customization/beagle-for-backend/beagle-framework.md
@@ -42,7 +42,7 @@ val mapper = // however your ObjectMapper is initialized
 mapper.registerModule(BeagleModule)
 ```
 
-Or you can use the function `beagleObjectMapper`. This function returns a `ObjectMapper` using `jacksonObjectMapper()`[**`https://github.com/ZupIT/beagle/pull/229/files`**](https://github.com/ZupIT/beagle/pull/229/files) with a  `BeagleModule` registered.
+Or you can use the function `beagleObjectMapper`. This function returns a `ObjectMapper` using `jacksonObjectMapper()` with a `BeagleModule` registered.
 
 ```kotlin
 val mapper = BeagleSerializationUtil.beagleObjectMapper()


### PR DESCRIPTION
remove unnecessary github link from beagle framework tutorial on backend customization (this link exists only on English pages)