### PR TITLE
refactor: trying to improve main overview page of the doc

### DIFF
--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -180,7 +180,7 @@ The `flex` attribute allows you to **use the same Layout Engine on different pla
 
 ### Actions
 
-Finally, let's talk about actions. They are a way to express dinamism inside Beagle. In the example, there is an action inside a button:
+Finally, let's talk about Actions, a way to add *runtime dynamism* to a Beagle component. In the example, there is an action inside a button:
 
 ```json
 {
@@ -196,11 +196,11 @@ Finally, let's talk about actions. They are a way to express dinamism inside Bea
 }
 ```
 
-The [Button component]({{< ref path="api/components/ui/button.md" >}}) has an attribute named `onPress` that can receive a list of actions, which will be executed when the button gets pressed. Beagle already comes with some actions, you can see them all in the [Actions section]({{< ref path="api/actions/_index.md" >}}). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
+The [Button component]({{< ref path="api/components/ui/button.md" >}}) has an attribute named `onPress` that can receive a list of actions, which will only be executed when the button gets pressed. You can see all Beagle's default actions in the [Actions section]({{< ref path="api/actions/_index.md" >}}). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
 
-This example uses an [Alert action]({{< ref path="api/actions/alert.md" >}}), which results in showing an alert component when someone taps the button. You can try it yourself in the *Playground*.
+This example uses an [Alert action]({{< ref path="api/actions/alert.md" >}}), which results in showing an alert component when someone taps the button. You can tap and see it yourself in the *Playground*.
 
-Besides showing an alert, you could do other things like:
+Besides showing an alert, you could do other things with actions, for example:
 
 - Navigate to another screen with a [Navigate action]({{< ref path="api/actions/navigate/_index.md" >}}).
 - Send an http request with a [SendRequest action]({{< ref path="api/actions/sendrequest.md" >}}).

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -143,13 +143,7 @@ Check out below, we used the `remote` image by providing a `url` which Beagle wi
 
 ### Styling
 
-Finally, let's take a closer look into the `style` attribute, which describes how to position and layout components and their children. Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**.
-
-You can experience that by changing the `flexDirection` attribute to **`ROW`** in the playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in your backend, and they will be reflected *immediately* in your frontend – even on mobile platforms, you don't need mobile store updates.
-
-> Many tools built in-house for Server Driven UI don't allow this kind of power over a UI positioning and this comes out of the box with Beagle.
-
-In the example *Container*, we are using 3 styling attributes: `flex`, `size`, and `backgroundColor`. There are other options as well, you can see them [in the Style section]({{< ref path="api/widget.md#style-attributes" >}}).
+Let's take a closer look into the `style` attribute, which describes how to position and layout components and their children:
 
 ```json
 {
@@ -172,11 +166,61 @@ In the example *Container*, we are using 3 styling attributes: `flex`, `size`, a
 }
 ```
 
+Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by changing the `flexDirection` attribute to **`ROW`** in the playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in your backend, and they will be reflected *immediately* in your frontend – even on mobile platforms, you don't need mobile store updates.
+
+> Many tools built in-house for Server Driven UI don't allow this kind of power over a UI positioning and this comes out of the box with Beagle.
+
+In the example *Container*, we are using 3 styling attributes: `flex`, `size`, and `backgroundColor`. There are other options as well, you can see them [in the Style section]({{< ref path="api/widget.md#style-attributes" >}}).
+
 The `flex` attribute allows you to **use the same Layout Engine on different platforms**. This can be a huge win for your team because all platforms will be positioning views according to the same rules, and you won't need to "duplicate" layout logic for each platform.
 
 - If you are familiar with web development, you probably know how to use `flex`. It is used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, Beagle uses a library called [**Yoga**](https://yogalayout.com), a C++ cross-platform library developed by Facebook and also used in other projects (e.g: React Native).
 
 - If you are not familiar with Flexbox, check out [the positioning section]({{< ref path="resources/components-positioning/_index.md" >}}), and the [Yoga's documentation](https://yogalayout.com/docs) for more details.
+
+### Actions
+
+Finally, let's talk about actions. They are a way to express dinamism inside Beagle. In the example, there is an action inside a button:
+
+```json
+{
+  "_beagleComponent_": "beagle:button",
+  "text": "Click here to show an Alert",
+  "onPress": [
+    {
+      "_beagleAction_": "beagle:alert",
+      "title": "My Title",
+      "message": "Alert message"
+    }
+  ]
+}
+```
+
+The [Button component](api/components/ui/button.md) has an attribute named `onPress` that can receive a list of actions, which will be executed when the button gets pressed. Beagle already comes with some actions, you can see them all in the [Actions section](api/actions/_index.md). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions](resources/customization/_index.md).
+
+This example uses an [Alert action](api/actions/alert.md), which results in showing an alert component when someone taps the button. You can try it yourself in the *Playground*.
+
+Besides showing an alert, you could do other things like:
+
+- Navigate to another screen with a [Navigate action](api/actions/navigate/_index.md).
+- Send an http request with a [SendRequest action](api/actions/sendrequest.md).
+- Add new views in the current view hierarchy with a [AddChildren action](api/actions/addchildren.md).
+
+Also, actions are one of the building blocks of **making complex and dynamic screens**. You can see more about this topic in the ["How to make communication between components" section](tutorials/how-to-make-communication-between-components.md).
+
+## Conclusion and next steps
+
+After seeing the most essential parts of Beagle, you are now ready to dive into more advanced topics:
+
+- If you want to see a more complex example of an application that completely leverages Beagle, you can check [this repo](https://github.com/ZupIT/beagle-adoption-demo). It has a backend in Kotlin, and native mobile frontends in Android and iOS.
+
+- If you want to integrate Beagle in your existing application, you can follow the [installation guide](get-started/installing-beagle/_index.md) for each platform, and then check the [start using Beagle section](get-started/using-beagle/_index.md).
+  
+- If you want to start a new project with Beagle, you can follow the ["creating a project from scratch" guide](get-started/creating-a-project-from-scratch/_index.md)
+
+- If you want to know more of a particular Beagle API, use the [API section](api/_index.md).
+
+- If you are not sure how to find information about a specific context, use the **search bar on the top right corner** of the screen to search for words throughout this documentation.
 
 ### Overview of Beagle's architecture
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -196,17 +196,17 @@ Finally, let's talk about actions. They are a way to express dinamism inside Bea
 }
 ```
 
-The [Button component](api/components/ui/button.md) has an attribute named `onPress` that can receive a list of actions, which will be executed when the button gets pressed. Beagle already comes with some actions, you can see them all in the [Actions section](api/actions/_index.md). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions](resources/customization/_index.md).
+The [Button component]({{< ref path="api/components/ui/button.md" >}}) has an attribute named `onPress` that can receive a list of actions, which will be executed when the button gets pressed. Beagle already comes with some actions, you can see them all in the [Actions section]({{< ref path="api/actions/_index.md" >}}). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
 
-This example uses an [Alert action](api/actions/alert.md), which results in showing an alert component when someone taps the button. You can try it yourself in the *Playground*.
+This example uses an [Alert action]({{< ref path="api/actions/alert.md" >}}), which results in showing an alert component when someone taps the button. You can try it yourself in the *Playground*.
 
 Besides showing an alert, you could do other things like:
 
-- Navigate to another screen with a [Navigate action](api/actions/navigate/_index.md).
-- Send an http request with a [SendRequest action](api/actions/sendrequest.md).
-- Add new views in the current view hierarchy with a [AddChildren action](api/actions/addchildren.md).
+- Navigate to another screen with a [Navigate action]({{< ref path="api/actions/navigate/_index.md" >}}).
+- Send an http request with a [SendRequest action]({{< ref path="api/actions/sendrequest.md" >}}).
+- Add new views in the current view hierarchy with a [AddChildren action]({{< ref path="api/actions/addchildren.md" >}}).
 
-Also, actions are one of the building blocks of **making complex and dynamic screens**. You can see more about this topic in the ["How to make communication between components" section](tutorials/how-to-make-communication-between-components.md).
+Also, actions are one of the building blocks of **making complex and dynamic screens**. You can see more about this topic in the ["How to make communication between components" section]({{< ref path="tutorials/how-to-make-communication-between-components.md" >}}).
 
 ## Conclusion and next steps
 
@@ -214,11 +214,11 @@ After seeing the most essential parts of Beagle, you are now ready to dive into 
 
 - If you want to see a more complex example of an application that completely leverages Beagle, you can check [this repo](https://github.com/ZupIT/beagle-adoption-demo). It has a backend in Kotlin, and native mobile frontends in Android and iOS.
 
-- If you want to integrate Beagle in your existing application, you can follow the [installation guide](get-started/installing-beagle/_index.md) for each platform, and then check the [start using Beagle section](get-started/using-beagle/_index.md).
+- If you want to integrate Beagle in your existing application, you can follow the [installation guide]({{< ref path="get-started/installing-beagle/_index.md" >}}) for each platform, and then check the [start using Beagle section]({{< ref path="get-started/using-beagle/_index.md" >}}).
   
-- If you want to start a new project with Beagle, you can follow the ["creating a project from scratch" guide](get-started/creating-a-project-from-scratch/_index.md)
+- If you want to start a new project with Beagle, you can follow the ["creating a project from scratch" guide]({{< ref path="get-started/creating-a-project-from-scratch/_index.md" >}})
 
-- If you want to know more of a particular Beagle API, use the [API section](api/_index.md).
+- If you want to know more of a particular Beagle API, use the [API section]({{< ref path="api/_index.md" >}}).
 
 - If you are not sure how to find information about a specific context, use the **search bar on the top right corner** of the screen to search for words throughout this documentation.
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -120,10 +120,30 @@ Now, let's take a closer look inside that JSON, so you can better understand Bea
 
 This is a **Component**, you can be sure because of the `_beagleComponent_` attribute. Beagle comes with a lot of useful components (you can navigate through them [in the components section]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, it is called **Custom Components**, but save that for later. The example uses a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), and it allows you to *group together* `children` components.
 
-There are other components with the *children* attribute (sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are usually used to **compose view hierarchies**.
+```json
+{
+  "_beagleComponent_": "beagle:container",
+  "style": {...},
+  "children": [
+    { 
+      "_beagleComponent_": "beagle:image",
+      ...
+    },
+    { 
+      "_beagleComponent_": "beagle:text",
+      ...
+    },
+    { 
+      "_beagleComponent_": "beagle:button",
+      ...
+    }
+  ]
+}
+```
 
-In this example, there are 3 other components inside the *Container*: [Text]({{< ref path="api/components/ui/text.md" >}}), [Image]({{< ref path="api/components/ui/image/_index.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). 
-Each one have different attributes, you can use to customize their rendering.
+> There are other components with the *children* attribute (sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are usually used to **compose view hierarchies**.
+
+In this example, there are 3 other components inside the *Container*: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes to customize their rendering, and you can see all available attributes in each component's API documentation.
 
 The *Image* component, for example, has an attribute named `path` that can receive `remote` or `local` paths to the image data.
 Check out below, we used the `remote` image by providing a `url` which Beagle will use to make a network request when the component gets rendered:
@@ -139,7 +159,7 @@ Check out below, we used the `remote` image by providing a `url` which Beagle wi
 }
 ```
 
-> You can have full control of the network request triggered by this remote image. You just need to configure your own Network Layer as a Beagle Dependency. To better understand how you can do that, or how to configure other Beagle Dependencies, you can check the [Customization section]({{< ref path="resources/customization/_index.md" >}}).
+> You can have full control of the network request triggered by this remote image. You just need to configure your own Network Layer as a Beagle Dependency. To better understand how to do that, or how to configure other Beagle Dependencies, you can check the [Customization section]({{< ref path="resources/customization/_index.md" >}}).
 
 ### Styling
 
@@ -166,11 +186,13 @@ Let's take a closer look into the `style` attribute, which describes how to posi
 }
 ```
 
-Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by changing the `flexDirection` attribute to **`ROW`** in the playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in your backend, and they will be reflected *immediately* in your frontend – even on mobile platforms, you don't need mobile store updates.
+Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by changing the `flexDirection` attribute to **`ROW`** in Playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in the backend, and it will be reflected *immediately* in the frontend – even on mobile platforms, you don't need mobile store updates.
 
 > Many tools built in-house for Server Driven UI don't allow this kind of power over a UI positioning and this comes out of the box with Beagle.
 
 In the example *Container*, we are using 3 styling attributes: `flex`, `size`, and `backgroundColor`. There are other options as well, you can see them [in the Style section]({{< ref path="api/widget.md#style-attributes" >}}).
+
+#### Flex
 
 The `flex` attribute allows you to **use the same Layout Engine on different platforms**. This can be a huge win for your team because all platforms will be positioning views according to the same rules, and you won't need to "duplicate" layout logic for each platform.
 
@@ -207,6 +229,8 @@ Besides showing an alert, you could do other things with actions, for example:
 - Add new views in the current view hierarchy with a [AddChildren action]({{< ref path="api/actions/addchildren.md" >}}).
 
 Also, actions are one of the building blocks of **making complex and dynamic screens**. You can see more about this topic in the ["How to make communication between components" section]({{< ref path="tutorials/how-to-make-communication-between-components.md" >}}).
+
+---
 
 ## Conclusion and next steps
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -218,7 +218,7 @@ Finally, let's talk about Actions, a way to add *runtime dynamism* to a Beagle c
 }
 ```
 
-The [Button component]({{< ref path="api/components/ui/button.md" >}}) has an attribute named `onPress` that can receive a list of actions, which will only be executed when the button gets pressed. You can see all Beagle's default actions in the [Actions section]({{< ref path="api/actions/_index.md" >}}). Mas também é possível criar suas próprias ações (um processo semelhante a *Custom Componentes*), que chamamos de [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
+The [Button component]({{< ref path="api/components/ui/button.md" >}}) has an attribute named `onPress` that can receive a list of actions, which will only be executed when the button gets pressed. You can see all Beagle's default actions in the [Actions section]({{< ref path="api/actions/_index.md" >}}). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
 
 This example uses an [Alert action]({{< ref path="api/actions/alert.md" >}}), which results in showing an alert component when someone taps the button. You can do that in the *Playground* and see it yourself.
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -15,15 +15,15 @@ Beagle is an **open source framework** that helps developers implement **Server-
 By using Beagle, developers can:
 
 {{% alert color="success" %}}
-- **Rapidly change an application layout, data, navigation flow, or even logic**, just by changing code in your backend
-- **Be more independent of mobile stores** (App Store and Play Store), since most changes won't need an app update
-- **Have more confidence that applications behave similar on different platforms**, since more code will be shared and standarized between backend and frontend
-- **Easily test new business hipothesis or make important fixes on live applications** to rapidly improve users experience and receive feedbacks
+- **Rapidly change an application layout, data, navigation flow, or even logic**: just by changing the code in your backend.
+- **Be more independent of mobile stores** like App Store and Play Store because most changes won't need an app update.
+- **Have more confidence that applications will behave similarly on different platforms** since the code will be shared and standardized between backend and frontend.
+- **Easily test a new business hypothesis or make important fixes on live applications** to improve users' experience and receive feedback.
 {{% /alert %}}
 
 ## How does Beagle work?
 
-The best way to understand how Beagle works is to see it in action. Here, we will show you a simple screen declared via Beagle, containing just texts, images, and some style configurations. At the end of this section, you will be familiar with Beagle's building blocks and most common features.
+The best way to understand Beagle is to see it in action. Here, we will show you a simple screen declared via Beagle, containing just texts, images, and some style configurations. At the end of this section, you will be familiar with Beagle's building blocks and most common features.
 
 <!-- json-playground:overview-simple-example.json
 {
@@ -93,13 +93,18 @@ The best way to understand how Beagle works is to see it in action. Here, we wil
 
 {{% playground file="overview-simple-example.json" language="en" %}}
 
-As you can see on the left side, we are declaring our screen with JSON. You can think of that JSON as what your backend provides to your frontend via a HTTP response. Frontend will then interpret it, and properly render it on the platform's screen (as you can see in the right side). Beagle provides libraries on both backend and frontend to completely handle this workflow for you.
+> Throughout the documentation, you will see examples – like the one above – that use a tool named **Playground**. By using it, you can:
+>
+> - Quickly see how Beagle works;
+> - Edit the code on the left and run it to see visual updates;
+> - Select different platforms to run your code on.
+> For more information about this tool, check out the [Playground section]({{< ref path="playground/_index.md" >}}).
 
-Just to clarify, we are using JSON here because it is the most straightforward way to use Beagle, but it's not the most productive and scalable. We actually have a "language" (DSL in Kotlin) that you should use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
+As you can see on the left side, we are declaring our screen with JSON. You can suppose this JSON is what your backend provides to your frontend via an HTTP response. The frontend will then interpret it, and properly render it on the platform's screen (as you can see on the right side). Beagle provides libraries on the backend and frontend to completely handle this workflow for you.
 
-Also, you can see which frontend platforms we support [here](#platforms-and-versions). They all render components **natively**, that is, if you want to use Beagle in a native mobile application on Android and iOS, our SDKs for these platforms will use native UIs (Android Views and UIKit, respectively), and you can even integrate your own native components to work with Beagle.
+Just to make it clear, in this example, we are using JSON because it is the most straightforward way to use Beagle, but it's not the most productive and scalable. Beagle actually has a "language" (DSL in Kotlin) that you should use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
 
-> Throughout our documentation, you will see examples which use this tool we call **Playground**. By using it, you can quickly see how Beagle work in real life. You can, as well, edit the code on the left, and select different platforms to run your code on. To better understand how to use this tool, you can check this [section]({{< ref path="playground/_index.md" >}}).
+Check out which frontend platforms Beagle supports [in the platforms and versions section](#platforms-and-versions). They all render components **natively**, for example, if you use Beagle in a native mobile application on Android and iOS, the SDKs for these platforms will use native UIs (Android Views and UIKit, respectively), and you can even integrate your own native components to work with Beagle.
 
 ### Components
 
@@ -113,11 +118,15 @@ Now, let's take a closer look inside that JSON, so you can better understand Bea
 }
 ```
 
-This is what we call a **Component**, and you can ensure that due to the attribute `_beagleComponent_`. Beagle comes with a bunch of useful components (you can navigate through them later [here]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, which we call **Custom Components**, but that will be discussed later. This one is a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), and it allows you to *group together* `children` components.
+This is a **Component**, you can be sure because of the `_beagleComponent_` attribute. Beagle comes with a lot of useful components (you can navigate through them [in the components section]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, it is called **Custom Components**, but save that for later. The example uses a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), and it allows you to *group together* `children` components.
 
-There are other components with the *children* attribute (or sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are usually used to **compose view hierarchies**. In this example, we have 3 other components inside *Container*: [Text]({{< ref path="api/components/ui/text.md" >}}), [Image]({{< ref path="api/components/ui/image/_index.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes you can use to customize their rendering, and you can see all these attributes in their documentation.
+There are other components with the *children* attribute (sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are usually used to **compose view hierarchies**.
 
-The *Image* component, for example, has this attribute named `path` that can receive `remote` or `local` paths to the image data. Here we use a `remote` image by providing a `url` which Beagle will use to request the image when the component gets rendered.
+In this example, there are 3 other components inside the *Container*: [Text]({{< ref path="api/components/ui/text.md" >}}), [Image]({{< ref path="api/components/ui/image/_index.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). 
+Each one have different attributes, you can use to customize their rendering.
+
+The *Image* component, for example, has an attribute named `path` that can receive `remote` or `local` paths to the image data.
+Check out below, we used the `remote` image by providing a `url` which Beagle will use to make a network request when the component gets rendered:
 
 ```json
 {
@@ -130,13 +139,17 @@ The *Image* component, for example, has this attribute named `path` that can rec
 }
 ```
 
-> You can have full control on the network request triggered by this remote image, you just need to configure your own Network Layer as a Beagle Dependency. Beagle have many configurable fragments like that and you can see more in [Customization]({{< ref path="resources/customization/_index.md" >}}).
+> You can have full control of the network request triggered by this remote image. You just need to configure your own Network Layer as a Beagle Dependency. To better understand how you can do that, or how to configure other Beagle Dependencies, you can check the [Customization section]({{< ref path="resources/customization/_index.md" >}}).
 
 ### Styling
 
-Finally, let's take a closer look into the `style` attribute, which describes how to position and layout components and their children. Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by chaging the `flexDirection` attribute to `ROW` in this page's playground, and you will see the same views positioned horizontally. In a real application, you could deploy this exact change in your backend, and they would be *immediately* reflected in your frontend – even on mobile platforms, without needing mobile stores update.
+Finally, let's take a closer look into the `style` attribute, which describes how to position and layout components and their children. Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**.
 
-> Many tools built in-house for Server Driven UI don't allow this kind of power over UI positioning, and this come out of the box with Beagle.
+You can experience that by changing the `flexDirection` attribute to **`ROW`** in the playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in your backend, and they will be reflected *immediately* in your frontend – even on mobile platforms, you don't need mobile store updates.
+
+> Many tools built in-house for Server Driven UI don't allow this kind of power over a UI positioning and this comes out of the box with Beagle.
+
+In the example *Container*, we are using 3 styling attributes: `flex`, `size`, and `backgroundColor`. There are other options as well, you can see them [in the Style section]({{< ref path="api/widget.md#style-attributes" >}}).
 
 ```json
 {
@@ -159,11 +172,11 @@ Finally, let's take a closer look into the `style` attribute, which describes ho
 }
 ```
 
-In our *Container*, we are using 3 styling attributes: `flex`, `size`, and `backgroundColor`. There are other options as well, you can see them all [here]({{< ref path="api/widget.md#style-attributes" >}}).
+The `flex` attribute allows you to **use the same Layout Engine on different platforms**. This can be a huge win for your team because all platforms will be positioning views according to the same rules, and you won't need to "duplicate" layout logic for each platform.
 
-The `flex` attribute is pretty important because it allows you to **use the same Layout Engine on different platforms**. Since all your platforms will be positioning views according to the same rules, and you don't need to "duplicate" the same layout logic for each platform, this can be a huge win for your team.
+- If you are familiar with web development, you probably know how to use `flex`. It is used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, Beagle uses a library called [**Yoga**](https://yogalayout.com), a C++ cross-platform library developed by Facebook and also used in other projects (e.g: React Native).
 
-If you are familiar with web development, you probably already know how to use `flex` because it's used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, we leverage a library called [**Yoga**](https://yogalayout.com), which is a cross-platform C++ library developed by Facebook and used in other projects (e.g: React Native). If you are not familiar with Flexbox, it takes some time to get used to it, but we bet you will really enjoy it due to its simplicity, power, and flexibility. [Our documentation]({{< ref path="resources/components-positioning/_index.md" >}}), and [Yoga's own documentation](https://yogalayout.com/docs) can help you to quickly understand it.
+- If you are not familiar with Flexbox, check out [the positioning section]({{< ref path="resources/components-positioning/_index.md" >}}), and the [Yoga's documentation](https://yogalayout.com/docs) for more details.
 
 ### Overview of Beagle's architecture
 
@@ -183,7 +196,7 @@ Beagle has different libraries/frameworks for each supported platform, in the fo
 - **Android:** [![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android)](https://mvnrepository.com/artifact/br.com.zup.beagle/android)
 - **iOS:** [![badge](https://img.shields.io/cocoapods/v/Beagle)](https://cocoapods.org/pods/Beagle)
 - **React Native:** [![react native badge](https://img.shields.io/npm/v/@zup-it/beagle-react-native?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react-native)
-- **Flutter:** *Being developed in this [folder](https://github.com/ZupIT/beagle/tree/master/flutter)*
+- **Flutter:** *It is being developed, check out more information [in this folder](https://github.com/ZupIT/beagle/tree/master/flutter)*
 - **SwiftUI and Compose:** we will try to support them in the future
 
 **Web:**

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -10,69 +10,74 @@ description: >-
 
 ## What is Beagle?
 
-Beagle is an **open source framework** of cross-platform development based on the implementation paradigm of **Server-Driven UI.**
+Beagle is an **open source framework** that helps developers implement **Server-Driven UI** in a **cross-platform** way.
 
-{{% alert color="warning" %}}
- Beagle's main benefit is that it allows teams to make **layout and data changes directly in native mobile or web applications** by changing the code on backend. 
-{{% /alert %}}
+By using Beagle, developers can:
 
-It's possible to create, test and quickly update native application's components without need to approve these changes on the store (App Store or Play Store).
-
-### Versioning
-
-Beagle's version follow the [**semantic versioning**](https://semver.org/) concept. The documentation is versioned according to the major Beagle version, meaning the main version. Between platforms, the features compatibility is by the minor version. For example, it is possible to use 1.0.0 in the backend with 1.0.1 on Android, 1.0.2 on iOS and 1.0.3 on the web react. 
-
-{{% alert color="info" %}}
-Beagle's current releases version are: 
-
-* **Android:**[![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android)](https://mvnrepository.com/artifact/br.com.zup.beagle/android)
-* **iOS:**[![badge](https://img.shields.io/cocoapods/v/Beagle)](https://cocoapods.org/pods/Beagle)
-* **WEB:** 
-  * **Angular:**[![badge](https://img.shields.io/npm/v/@zup-it/beagle-angular?logo=Angular)](https://www.npmjs.com/package/@zup-it/beagle-angular)
-  * **React:**[![badge](https://img.shields.io/npm/v/@zup-it/beagle-react?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react)
-* **React Native:**[![react native badge](https://img.shields.io/npm/v/@zup-it/beagle-react-native?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react-native)
-* **Backend:**[![back](https://camo.githubusercontent.com/27998a386042ecb2cae7b9f09ae159bd07c935bd/68747470733a2f2f696d672e736869656c64732e696f2f6d6176656e2d63656e7472616c2f762f62722e636f6d2e7a75702e626561676c652f6672616d65776f726b)](https://mvnrepository.com/artifact/br.com.zup.beagle/framework)
-{{% /alert %}}
-
-Some definitions on this documentation exists only only in some specific minors or patches. See the captions used to denote these cases:
-
-* `x.y.z`: an exclusive definition of the version x.y.z; 
-* `>=x.y.z`: existing definition from x.y.z version;
-* `<=x.y.z`: existing definition until the x.y.z version. 
+- **Rapidly change an application layout, data, navigation flow, or even logic**, just by changing code in your backend
+- **Be more independent of mobile stores** (App Store and Play Store), since most changes won't need an app update
+- **Have more confidence that their application behaves similar on different platforms**, since more code will be shared and standarized between backend and frontend
+- **Easily test new business hipothesis or make important fixes on live applications** to rapidly improve users experience and receive feedbacks
 
 ## How does Beagle work?
 
-The tool works as a facilitator of **BFF** \([**Backend For Frontend**]({{< ref path="/key-concepts#backend-for-frontend" lang="en" >}})\). This means that Beagle, from a library of components defined in the [**Design System**]({{< ref path="/key-concepts#design-system" lang="en" >}}) of the Android, iOS or Web application, makes the visual and behavioral change of them by returning a JSON file that indicates what and where each component should be rendered and which the action they are going to perform.
+### Simple Example
 
-![](/shared/beaglemobileback.png)
+Here we will show you a simple screen declared via Beagle, containing just texts, images, and some layout and style configurations:
 
-  
-The reason Beagle is able to make this frontend change from the backend is because its architecture is structured in [**Server-Driven UI**]({{< ref path="/key-concepts#server-driven-ui" lang="en" >}}), where BFF builds the data, components and actions present on the screen in a declarative way, and forwards them in a JSON format, while the front-end deserializes it, renders the visual components natively in addition to executing and assigning the actions present in each of them.
+{{% playground language="en" %}}
 
-### Beagle's Pillars 
+As you can see on the left side, we are declaring our screen with JSON. You can think of that JSON as what your backend provides to your frontend via a service call. The frontend will then interpret it, and properly render it on the platform's screen (as you can see in the right side). Beagle provides libraries on the backend and frontend to completely handle this workflow for you.
 
-Considering that it's a tool based on Server-Driven, the JSON objects configured to run your application can be organized in 3 basic pillars: 
+Just to clarify, we are using JSON here because it is the most straightforward way to use Beagle, but it's not the most productive and scalable. We actually have a "language" (DSL in Kotlin) that you should use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
 
-* Content
-* Visual Structure 
-* Flow \(or Actions\) 
+Throughout our documentation, you will see examples which use this tool we call **Playground**. By using it, you can quickly see how Beagle APIs work in real life. You can as well edit the code on the left, and run it on different platforms just by selecting it inside the playground. To better understand how to use this tool, you can go [here](playground/_index.md).
 
-After defining in the frontend and backend how the visual structure of the application will be with the customized components and actions, as well as how they can be changed, the BFF will be able to communicate with the front.
+#### Components
 
-In this way, new features, flows, customizations and combinations of visual components can be tested without the need to publish updates to the application, optimizing type A / B tests.
+Now, let's take a closer look inside this JSON, so you can better understand Beagle's capabilites. The first thing to notice is this structure:
 
-![](/shared/beaglecomp.png)
+```json
+{
+  "_beagleComponent_": "beagle:container",
+  "style": {},
+  "children": []
+}
+```
 
-## Why use Beagle?
+This is what we call a **Component**, and you can visualize that due to the presence of `_beagleComponent_` property. Beagle comes with a bunch of useful components (you can navigate through them later [here](api/components/_index.md)), and you can also define your own components, we call that **Custom Components**, but that's a later topic. This one is a really basic and important component named [Container](api/components/layout/container.md), it allows you to group other components. That's why it has a property named `children`
 
-{{% alert color="success" %}}
-Beagle was created to **optimize time and resources** for development's, design's and business' teams to publish and keep updated their applications without need to approve it on App Store or Play Store and, also, respecting the application's design system. 
+### Overview of Beagle's architecture
+
+![An overview of Beagle's architecture](/shared/beaglemobileback.png)
+
+---
+
+## Platforms and Versions
+
+Beagle has different libraries/frameworks for each supported platform, in the following list you can see and access the most up to date versions:
+
+{{% alert color="info" %}}
+**Backend Kotlin:** [![back](https://camo.githubusercontent.com/27998a386042ecb2cae7b9f09ae159bd07c935bd/68747470733a2f2f696d672e736869656c64732e696f2f6d6176656e2d63656e7472616c2f762f62722e636f6d2e7a75702e626561676c652f6672616d65776f726b)](https://mvnrepository.com/artifact/br.com.zup.beagle/framework)
+
+**Mobile**:
+
+- **Android:** [![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android)](https://mvnrepository.com/artifact/br.com.zup.beagle/android)
+- **iOS:** [![badge](https://img.shields.io/cocoapods/v/Beagle)](https://cocoapods.org/pods/Beagle)
+- **React Native:** [![react native badge](https://img.shields.io/npm/v/@zup-it/beagle-react-native?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react-native)
+
+**Web:**
+
+- **Angular:** [![badge](https://img.shields.io/npm/v/@zup-it/beagle-angular?logo=Angular)](https://www.npmjs.com/package/@zup-it/beagle-angular)
+- **React:** [![badge](https://img.shields.io/npm/v/@zup-it/beagle-react?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react)
 {{% /alert %}}
 
-The main advantages of using Beagle on your project are: 
+### Understanding version numbers
 
-* **More flexibility at work**, specially among developers and UI/UX designers when it's necessary to make specific changes.  
-* **Easy app maintenance** which enables to make constant tests to improve your application.  
-* **Minor risks of duplicate code** because all consumption of APIs, flows and rules will be in one place, BFF.
+Beagle's version follows the [semantic versioning](https://semver.org/) concept. The documentation is versioned according to the *major* Beagle version. Between platforms, the features compatibility is by the minor version. For example, it is possible to use 1.0.0 in the backend with 1.0.1 on Android, 1.0.2 on iOS and 1.0.3 on the web react.
 
-Another fundamental gain is that Beagle allows you to **reduce user's feedback time**, once that the changes are quickly done, tested and validated.
+Some definitions on this documentation exists only in some specific minors or patches. See the captions used to denote these cases:
+
+- `x.y.z`: an exclusive definition of the version x.y.z;
+- `>=x.y.z`: existing definition from x.y.z version;
+- `<=x.y.z`: existing definition until the x.y.z version.

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -75,6 +75,17 @@ The best way to understand how Beagle works is to see it in action. Here, we wil
           }
         }
       }
+    },
+    {
+      "_beagleComponent_": "beagle:button",
+      "text": "Click here to show an Alert",
+      "onPress": [
+        {
+          "_beagleAction_": "beagle:alert",
+          "title": "My Title",
+          "message": "Alert message"
+        }
+      ]
     }
   ]
 }

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -23,7 +23,13 @@ By using Beagle, developers can:
 
 ## How does Beagle work?
 
-The best way to understand Beagle is to see it in action. Here, we will show you a simple screen declared via Beagle, containing just texts, images, and some style configurations. At the end of this section, you will be familiar with Beagle's most common features.
+The best way to understand Beagle is to see it in action. That's why we'll show you **how to build a simple screen with Beagle**.
+
+We'll comment on each piece of the screen (text, image, button, and style settings), and leave links to other parts of the documentation that go into more detail. By the end of this page, you'll become familiar with the most common features of Beagle.
+
+> The links to other pages are only for further information, you don't need to access them right away.
+
+That said, here's the screen we will discuss:
 
 <!-- json-playground:overview-simple-example.json
 {
@@ -101,7 +107,7 @@ The best way to understand Beagle is to see it in action. Here, we will show you
 >
 > For more information about this tool, check out the [Playground section]({{< ref path="playground/_index.md" >}}).
 
-As you can see on the left side, we are declaring our screen with JSON. This JSON is what your backend would provide to your frontend via an HTTP response. The frontend will then interpret it, and properly render it on the platform's screen (as you can see on the right side). Beagle provides libraries on the backend and frontend to handle this workflow for you.
+As you can see on the left side, we are declaring our screen with JSON. This JSON is what the backend would provide to the frontend via an HTTP response. The frontend will then interpret it, and properly render it on the platform's screen (as you can see on the right side). Beagle provides libraries on the backend and frontend to handle this workflow for you.
 
 We use JSON in the examples because it is the most straightforward way to use Beagle. However, Beagle actually has a "language" (DSL in Kotlin) that you can use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
 
@@ -150,9 +156,7 @@ Check out below, we used a `remote` path by providing a `url` which Beagle will 
 
 > You can have full control of the network request triggered by this remote image. You just need to configure your own *Network Layer* as a *Beagle Dependency*. To better understand how to do that, or how to configure other Beagle Dependencies, you can check the [Customization section]({{< ref path="resources/customization/_index.md" >}}).
 
-Beagle comes with a lot of useful components, you can navigate through all them in [the components section]({{< ref path="api/components/_index.md" >}}). You can also define your own components, which are called [Custom Components]({{< ref path="resources/customization/_index.md" >}}), but save that for later.
-
-> The *children* attribute (sometimes just *child*) is present in other components like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are also used to **compose view hierarchies**.
+Beagle already comes with a lot of useful components, you can browse them all in the [components section]({{< ref path="api/components/_index.md" >}}). There are other components, for example, that have the *children* attribute (sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are used to *compose view hierarchies* like a *Container*. You can also define your own components, called [Custom Components]({{< ref path="resources/customization/_index.md" >}}), and use them in a very similar way to a component that comes with Beagle.
 
 ### Styling
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -15,15 +15,15 @@ Beagle is an **open source framework** that helps developers implement **Server-
 By using Beagle, developers can:
 
 {{% alert color="success" %}}
-- **Rapidly change an application layout, data, navigation flow, or even logic**: just by changing the code in your backend.
-- **Be more independent of mobile stores** like App Store and Play Store because most changes won't need an app update.
-- **Have more confidence that applications will behave similarly on different platforms** since the code will be shared and standardized between backend and frontend.
-- **Easily test a new business hypothesis or make important fixes on live applications** to improve users' experience and receive feedback.
+- **Rapidly change an application layout, data, navigation flow, or even logic**, just by changing code in the backend.
+- **Be more independent of mobile stores**, like App Store and Play Store, because most changes won't need an app update.
+- **Have more confidence that applications will behave similarly on different platforms**, since code will be shared and standardized between backend and frontend.
+- **Easily test new business hypothesis or make live fixes on applications** to improve users' experience and receive feedback.
 {{% /alert %}}
 
 ## How does Beagle work?
 
-The best way to understand Beagle is to see it in action. Here, we will show you a simple screen declared via Beagle, containing just texts, images, and some style configurations. At the end of this section, you will be familiar with Beagle's building blocks and most common features.
+The best way to understand Beagle is to see it in action. Here, we will show you a simple screen declared via Beagle, containing just texts, images, and some style configurations. At the end of this section, you will be familiar with Beagle's most common features.
 
 <!-- json-playground:overview-simple-example.json
 {
@@ -104,7 +104,7 @@ As you can see on the left side, we are declaring our screen with JSON. You can 
 
 Just to make it clear, in this example, we are using JSON because it is the most straightforward way to use Beagle, but it's not the most productive and scalable. Beagle actually has a "language" (DSL in Kotlin) that you should use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
 
-Check out which frontend platforms Beagle supports [in the platforms and versions section](#platforms-and-versions). They all render components **natively**, for example, if you use Beagle in a native mobile application on Android and iOS, the SDKs for these platforms will use native UIs (Android Views and UIKit, respectively), and you can even integrate your own native components to work with Beagle.
+Check out which frontend platforms Beagle supports [in the platforms and versions section](#platforms-and-versions). They all render components **natively**, for example, if you use Beagle in a native mobile application on Android or iOS, the libraries for these platforms will use native UIs (Android Views and UIKit, respectively), and you can even integrate your own native components to work with Beagle.
 
 ### Components
 
@@ -118,7 +118,7 @@ Now, let's take a closer look inside that JSON, so you can better understand Bea
 }
 ```
 
-This is a **Component**, you can be sure because of the `_beagleComponent_` attribute. Beagle comes with a lot of useful components (you can navigate through them [in the components section]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, it is called **Custom Components**, but save that for later. The example uses a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), and it allows you to *group together* `children` components.
+This is a **Component**, you can be sure because of the `_beagleComponent_` attribute. Beagle comes with a lot of useful components (you can navigate through them [in the components section]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, it is called **Custom Components**, but save that for later. The example uses a simple and common component named [Container]({{< ref path="api/components/layout/container.md" >}}), and it allows you to *group together* `children` components.
 
 ```json
 {
@@ -141,7 +141,7 @@ This is a **Component**, you can be sure because of the `_beagleComponent_` attr
 }
 ```
 
-> There are other components with the *children* attribute (sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are usually used to **compose view hierarchies**.
+> There are other components with the *children* attribute (sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are used to **compose view hierarchies**.
 
 In this example, there are 3 components inside the *Container*: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes to customize their rendering, and you can see all available attributes in each component's API documentation.
 
@@ -159,7 +159,7 @@ Check out below, we used the `remote` image by providing a `url` which Beagle wi
 }
 ```
 
-> You can have full control of the network request triggered by this remote image. You just need to configure your own Network Layer as a Beagle Dependency. To better understand how to do that, or how to configure other Beagle Dependencies, you can check the [Customization section]({{< ref path="resources/customization/_index.md" >}}).
+> You can have full control of the network request triggered by this remote image. You just need to configure your own *Network Layer* as a *Beagle Dependency*. To better understand how to do that, or how to configure other Beagle Dependencies, you can check the [Customization section]({{< ref path="resources/customization/_index.md" >}}).
 
 ### Styling
 
@@ -186,17 +186,17 @@ Let's take a closer look into the `style` attribute, which describes how to posi
 }
 ```
 
-Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by changing the `flexDirection` attribute to **`ROW`** in Playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in the backend, and it will be reflected *immediately* in the frontend – even on mobile platforms, you don't need mobile store updates.
+Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by changing the `flexDirection` attribute to **`ROW`** in Playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in the backend, and it will be reflected *immediately* in the frontend – even on mobile platforms, you don't need store updates.
 
 > Many tools built in-house for Server Driven UI don't allow this kind of power over a UI positioning and this comes out of the box with Beagle.
 
-In the example *Container*, we are using 3 styling attributes: `flex`, `size`, and `backgroundColor`. There are other options as well, you can see them [in the Style section]({{< ref path="api/widget.md#style-attributes" >}}).
+In the example's *Container*, we are using 3 styling attributes: `flex`, `size`, and `backgroundColor`. There are other options as well, you can see them [in the Style section]({{< ref path="api/widget.md#style-attributes" >}}).
 
 #### Flex
 
 The `flex` attribute allows you to **use the same Layout Engine on different platforms**. This can be a huge win for your team because all platforms will be positioning views according to the same rules, and you won't need to "duplicate" layout logic for each platform.
 
-- If you are familiar with web development, you probably know how to use `flex`. It is used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, Beagle uses a library called [**Yoga**](https://yogalayout.com), a C++ cross-platform library developed by Facebook and also used in other projects (e.g: React Native).
+- If you have experience with web development, you probably already know how to use `flex`, since it is used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this, Beagle uses a library called [**Yoga**](https://yogalayout.com), a cross-platform library developed in C++ by Facebook, and also used in other projects (e.g: React Native).
 
 - If you are not familiar with Flexbox, check out [the positioning section]({{< ref path="resources/components-positioning/_index.md" >}}), and the [Yoga's documentation](https://yogalayout.com/docs) for more details.
 
@@ -218,11 +218,11 @@ Finally, let's talk about Actions, a way to add *runtime dynamism* to a Beagle c
 }
 ```
 
-The [Button component]({{< ref path="api/components/ui/button.md" >}}) has an attribute named `onPress` that can receive a list of actions, which will only be executed when the button gets pressed. You can see all Beagle's default actions in the [Actions section]({{< ref path="api/actions/_index.md" >}}). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
+The [Button component]({{< ref path="api/components/ui/button.md" >}}) has an attribute named `onPress` that can receive a list of actions, which will only be executed when the button gets pressed. You can see all Beagle's default actions in the [Actions section]({{< ref path="api/actions/_index.md" >}}). Mas também é possível criar suas próprias ações (um processo semelhante a *Custom Componentes*), que chamamos de [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
 
-This example uses an [Alert action]({{< ref path="api/actions/alert.md" >}}), which results in showing an alert component when someone taps the button. You can tap and see it yourself in the *Playground*.
+This example uses an [Alert action]({{< ref path="api/actions/alert.md" >}}), which results in showing an alert component when someone taps the button. You can do that in the *Playground* and see it yourself.
 
-Besides showing an alert, you could do other things with actions, for example:
+Besides showing an alert, you can use actions to:
 
 - Navigate to another screen with a [Navigate action]({{< ref path="api/actions/navigate/_index.md" >}}).
 - Send an http request with a [SendRequest action]({{< ref path="api/actions/sendrequest.md" >}}).
@@ -234,7 +234,7 @@ Also, actions are one of the building blocks of **making complex and dynamic scr
 
 ## Conclusion and next steps
 
-After seeing the most essential parts of Beagle, you are now ready to dive into more advanced topics:
+After seeing Beagle's most essential parts, you are now ready to dive into more advanced topics:
 
 - If you want to see a more complex example of an application that completely leverages Beagle, you can check [this repo](https://github.com/ZupIT/beagle-adoption-demo). It has a backend in Kotlin, and native mobile frontends in Android and iOS.
 
@@ -242,9 +242,9 @@ After seeing the most essential parts of Beagle, you are now ready to dive into 
   
 - If you want to start a new project with Beagle, you can follow the ["creating a project from scratch" guide]({{< ref path="get-started/creating-a-project-from-scratch/_index.md" >}})
 
-- If you want to know more of a particular Beagle API, use the [API section]({{< ref path="api/_index.md" >}}).
+- If you want to know more of a particular API, use the [API section]({{< ref path="api/_index.md" >}}).
 
-- If you are not sure how to find information about a specific context, use the **search bar on the top right corner** of the screen to search for words throughout this documentation.
+- If you are not sure how to find information about a specific context, use the **search bar on the top right corner of the screen** to search for words throughout this documentation.
 
 ### Overview of Beagle's architecture
 
@@ -275,10 +275,8 @@ Beagle has different libraries/frameworks for each supported platform, in the fo
 
 ### Understanding version numbers
 
-Beagle's version follows the [semantic versioning](https://semver.org/) concept. The documentation is versioned according to the *major* Beagle version. Between platforms, the features compatibility is by the minor version. For example, it is possible to use 1.0.0 in the backend with 1.0.1 on Android, 1.0.2 on iOS and 1.0.3 on the web react.
+Beagle's version follows the [semantic versioning](https://semver.org/) standard.
 
-Some definitions on this documentation exists only in specific minors or patches. See the captions used to denote these cases:
+The *documentation* only has versions with numbers up to the **minor**, for example: `1.2`. However, some definitions from previous minor versions may still be present, even if they are not valid anymore. If that's the case, we will try to inform those definitions specific versions.
 
-- `x.y.z`: an exclusive definition of the version x.y.z;
-- `>=x.y.z`: existing definition from x.y.z version;
-- `<=x.y.z`: existing definition until the x.y.z version.
+Between platforms, it's possible to use different **patch** versions. For example, you can have version `1.0.0` in the backend with `1.0.1` on Android, `1.0.2` on iOS, and `1.0.3` on the web react.

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -23,7 +23,7 @@ By using Beagle, developers can:
 
 ## How does Beagle work?
 
-The best way to understand how Beagle works is to see it in action. Here, we will show you a simple screen declared via Beagle containing just texts, images, and some layout and style configurations. At the end of this section, you will be familiar with Beagle's building blocks and most common features.
+The best way to understand how Beagle works is to see it in action. Here, we will show you a simple screen declared via Beagle, containing just texts, images, and some style configurations. At the end of this section, you will be familiar with Beagle's building blocks and most common features.
 
 <!-- json-playground:overview-simple-example.json
 {
@@ -92,7 +92,7 @@ Also, you can see which frontend platforms we support [here](#platforms-and-vers
 
 ### Components
 
-Now, let's take a closer look inside this JSON, so you can better understand Beagle's capabilites. The first thing to notice is this structure:
+Now, let's take a closer look inside that JSON, so you can better understand Beagle's capabilities. The first thing to notice is its structure:
 
 ```json
 {
@@ -102,11 +102,11 @@ Now, let's take a closer look inside this JSON, so you can better understand Bea
 }
 ```
 
-This is what we call a **Component**, and you can ensure that due to the attribute `_beagleComponent_`. Beagle comes with a bunch of useful components (you can navigate through them later [here]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, which we call **Custom Components**, but that's a later topic. This one is a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), it allows you to *group together* those components inside attribute `children`.
+This is what we call a **Component**, and you can ensure that due to the attribute `_beagleComponent_`. Beagle comes with a bunch of useful components (you can navigate through them later [here]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, which we call **Custom Components**, but that will be discussed later. This one is a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), and it allows you to *group together* `children` components.
 
 There are other components with the *children* attribute (or sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are usually used to **compose view hierarchies**. In this example, we have 3 other components inside *Container*: [Text]({{< ref path="api/components/ui/text.md" >}}), [Image]({{< ref path="api/components/ui/image/_index.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes you can use to customize their rendering, and you can see all these attributes in their documentation.
 
-The *Image* component, for example, has this attribute named `path` that can receive `remote` or `local` paths to the image data. Here we use a `remote` image by providing an `url` which Beagle will use to request the image when the component gets rendered.
+The *Image* component, for example, has this attribute named `path` that can receive `remote` or `local` paths to the image data. Here we use a `remote` image by providing a `url` which Beagle will use to request the image when the component gets rendered.
 
 ```json
 {
@@ -119,11 +119,11 @@ The *Image* component, for example, has this attribute named `path` that can rec
 }
 ```
 
-> You can have full control on the network request triggered by this remote image, you just need to configure your own Network Layer as a Beagle Dependency. Beagle have many configurable pieces like this, you can see more in [Customization]({{< ref path="resources/customization/_index.md" >}}).
+> You can have full control on the network request triggered by this remote image, you just need to configure your own Network Layer as a Beagle Dependency. Beagle have many configurable fragments like that and you can see more in [Customization]({{< ref path="resources/customization/_index.md" >}}).
 
 ### Styling
 
-Finally, let's take a closer look into the `style` attribute, which describes how to position and layout components and their children. Most of components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can see this power by chaging the `flexDirection` attribute to `ROW` inside the playground, and you will see the same views positioned horizontally. In a real application, you could deploy this exact change in your backend, and they would be *immediately* reflected in your frontend – even on mobile platforms, without needing mobile stores update.
+Finally, let's take a closer look into the `style` attribute, which describes how to position and layout components and their children. Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by chaging the `flexDirection` attribute to `ROW` in this page's playground, and you will see the same views positioned horizontally. In a real application, you could deploy this exact change in your backend, and they would be *immediately* reflected in your frontend – even on mobile platforms, without needing mobile stores update.
 
 > Many tools built in-house for Server Driven UI don't allow this kind of power over UI positioning, and this come out of the box with Beagle.
 
@@ -152,7 +152,7 @@ In our *Container*, we are using 3 styling attributes: `flex`, `size`, and `back
 
 The `flex` attribute is pretty important because it allows you to **use the same Layout Engine on different platforms**. Since all your platforms will be positioning views according to the same rules, and you don't need to "duplicate" the same layout logic for each platform, this can be a huge win for your team.
 
-If you are familiar with web development, you probably already know how to use `flex` because it's used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, we leverage a library called [**Yoga**](https://yogalayout.com), a cross-platform C++ library developed by Facebook and used in other projects (e.g: React Native). If you are not familiar with Flexbox, it takes some time to get used to it, but we bet you will really enjoy it due to its simplicity, power, and universality. [Our documentation]({{< ref path="resources/components-positioning/_index.md" >}}), and [Yoga's own documentation](https://yogalayout.com/docs) can help you to quickly understand it.
+If you are familiar with web development, you probably already know how to use `flex` because it's used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, we leverage a library called [**Yoga**](https://yogalayout.com), which is a cross-platform C++ library developed by Facebook and used in other projects (e.g: React Native). If you are not familiar with Flexbox, it takes some time to get used to it, but we bet you will really enjoy it due to its simplicity, power, and flexibility. [Our documentation]({{< ref path="resources/components-positioning/_index.md" >}}), and [Yoga's own documentation](https://yogalayout.com/docs) can help you to quickly understand it.
 
 ### Overview of Beagle's architecture
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -277,6 +277,6 @@ Beagle has different libraries/frameworks for each supported platform, in the fo
 
 Beagle's version follows the [semantic versioning](https://semver.org/) standard.
 
-The *documentation* only has versions with numbers up to the **minor**, for example: `1.2`. However, some definitions from previous minor versions may still be present, even if they are not valid anymore. If that's the case, we will try to inform those definitions specific versions.
+Between platforms, the last number (**patch**) tends to diverge, as some bugs only occur on a certain platform. So, the following example is normal and expected: having version `1.0.0` in the backend with `1.0.2` in Android, `1.0.0` in iOS, and `1.0.3` in web React.
 
-Between platforms, it's possible to use different **patch** versions. For example, you can have version `1.0.0` in the backend with `1.0.1` on Android, `1.0.2` on iOS, and `1.0.3` on the web react.
+The *documentation* only has versions with numbers up to the **minor**, for example: `1.2`. However, some definitions from previous minor versions may still be present, even if they are not valid anymore. If that's the case, we will try to inform those definitions specific versions.

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -143,7 +143,7 @@ This is a **Component**, you can be sure because of the `_beagleComponent_` attr
 
 > There are other components with the *children* attribute (sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are usually used to **compose view hierarchies**.
 
-In this example, there are 3 other components inside the *Container*: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes to customize their rendering, and you can see all available attributes in each component's API documentation.
+In this example, there are 3 components inside the *Container*: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes to customize their rendering, and you can see all available attributes in each component's API documentation.
 
 The *Image* component, for example, has an attribute named `path` that can receive `remote` or `local` paths to the image data.
 Check out below, we used the `remote` image by providing a `url` which Beagle will use to make a network request when the component gets rendered:
@@ -277,7 +277,7 @@ Beagle has different libraries/frameworks for each supported platform, in the fo
 
 Beagle's version follows the [semantic versioning](https://semver.org/) concept. The documentation is versioned according to the *major* Beagle version. Between platforms, the features compatibility is by the minor version. For example, it is possible to use 1.0.0 in the backend with 1.0.1 on Android, 1.0.2 on iOS and 1.0.3 on the web react.
 
-Some definitions on this documentation exists only in some specific minors or patches. See the captions used to denote these cases:
+Some definitions on this documentation exists only in specific minors or patches. See the captions used to denote these cases:
 
 - `x.y.z`: an exclusive definition of the version x.y.z;
 - `>=x.y.z`: existing definition from x.y.z version;

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -104,7 +104,7 @@ Now, let's take a closer look inside this JSON, so you can better understand Bea
 
 This is what we call a **Component**, and you can ensure that due to the attribute `_beagleComponent_`. Beagle comes with a bunch of useful components (you can navigate through them later [here]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, which we call **Custom Components**, but that's a later topic. This one is a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), it allows you to *group together* those components inside attribute `children`.
 
-There are other components with the *children* attribute (or sometimes just *child*) like [Screen](api/screen/_index.md) and [ListView](api/components/layout/listview.md), and they are usually used to **compose view hierarchies**. In this example, we have 3 other components inside *Container*: [Text](api/components/ui/text.md), [Image](api/components/ui/image/_index.md), and [Button](api/components/ui/button.md). Each one have different attributes you can use to customize their rendering, and you can see all these attributes in their documentation.
+There are other components with the *children* attribute (or sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are usually used to **compose view hierarchies**. In this example, we have 3 other components inside *Container*: [Text]({{< ref path="api/components/ui/text.md" >}}), [Image]({{< ref path="api/components/ui/image/_index.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes you can use to customize their rendering, and you can see all these attributes in their documentation.
 
 The *Image* component, for example, has this attribute named `path` that can receive `remote` or `local` paths to the image data. Here we use a `remote` image by providing an `url` which Beagle will use to request the image when the component gets rendered.
 
@@ -119,7 +119,7 @@ The *Image* component, for example, has this attribute named `path` that can rec
 }
 ```
 
-> You can have full control on the network request triggered by this remote image, you just need to configure your own Network Layer as a Beagle Dependency. Beagle have many configurable pieces like this, you can see more in [Customization](resources/customization/_index.md).
+> You can have full control on the network request triggered by this remote image, you just need to configure your own Network Layer as a Beagle Dependency. Beagle have many configurable pieces like this, you can see more in [Customization]({{< ref path="resources/customization/_index.md" >}}).
 
 ### Styling
 
@@ -152,7 +152,7 @@ In our *Container*, we are using 3 styling attributes: `flex`, `size`, and `back
 
 The `flex` attribute is pretty important because it allows you to **use the same Layout Engine on different platforms**. Since all your platforms will be positioning views according to the same rules, and you don't need to "duplicate" the same layout logic for each platform, this can be a huge win for your team.
 
-If you are familiar with web development, you probably already know how to use `flex` because it's used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, we leverage a library called [**Yoga**](https://yogalayout.com), a cross-platform C++ library developed by Facebook and used in other projects (e.g: React Native). If you are not familiar with Flexbox, it takes some time to get used to it, but we bet you will really enjoy it due to its simplicity, power, and universality. [Our documentation](resources/components-positioning/_index.md), and [Yoga's own documentation](https://yogalayout.com/docs) can really help you to quickly understand it.
+If you are familiar with web development, you probably already know how to use `flex` because it's used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, we leverage a library called [**Yoga**](https://yogalayout.com), a cross-platform C++ library developed by Facebook and used in other projects (e.g: React Native). If you are not familiar with Flexbox, it takes some time to get used to it, but we bet you will really enjoy it due to its simplicity, power, and universality. [Our documentation]({{< ref path="resources/components-positioning/_index.md" >}}), and [Yoga's own documentation](https://yogalayout.com/docs) can help you to quickly understand it.
 
 ### Overview of Beagle's architecture
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -93,18 +93,19 @@ The best way to understand Beagle is to see it in action. Here, we will show you
 
 {{% playground file="overview-simple-example.json" language="en" %}}
 
-> Throughout the documentation, you will see examples – like the one above – that use a tool named **Playground**. By using it, you can:
+> Throughout the documentation, you will see examples – like the one above – that use a tool we made named **Playground**. By using it, you can:
 >
 > - Quickly see how Beagle works;
-> - Edit the code on the left and run it to see visual updates;
+> - Edit the code on the left, run it, and observe the result;
 > - Select different platforms to run your code on.
+>
 > For more information about this tool, check out the [Playground section]({{< ref path="playground/_index.md" >}}).
 
-As you can see on the left side, we are declaring our screen with JSON. You can suppose this JSON is what your backend provides to your frontend via an HTTP response. The frontend will then interpret it, and properly render it on the platform's screen (as you can see on the right side). Beagle provides libraries on the backend and frontend to completely handle this workflow for you.
+As you can see on the left side, we are declaring our screen with JSON. This JSON is what your backend would provide to your frontend via an HTTP response. The frontend will then interpret it, and properly render it on the platform's screen (as you can see on the right side). Beagle provides libraries on the backend and frontend to handle this workflow for you.
 
-Just to make it clear, in this example, we are using JSON because it is the most straightforward way to use Beagle, but it's not the most productive and scalable. Beagle actually has a "language" (DSL in Kotlin) that you should use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
+We use JSON in the examples because it is the most straightforward way to use Beagle. However, Beagle actually has a "language" (DSL in Kotlin) that you can use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
 
-Check out which frontend platforms Beagle supports [in the platforms and versions section](#platforms-and-versions). They all render components **natively**, for example, if you use Beagle in a native mobile application on Android or iOS, the libraries for these platforms will use native UIs (Android Views and UIKit, respectively), and you can even integrate your own native components to work with Beagle.
+Check out which frontend platforms Beagle supports [in the platforms and versions section](#platforms-and-versions). They all render components **natively**, that is, if you use Beagle in a native mobile application on Android or iOS, the libraries for these platforms will use native UIs (Android Views and UIKit, respectively), and you can even integrate your own native components to work with Beagle.
 
 ### Components
 
@@ -114,26 +115,16 @@ Now, let's take a closer look inside that JSON, so you can better understand Bea
 {
   "_beagleComponent_": "beagle:container",
   "style": {...},
-  "children": [...]
-}
-```
-
-This is a **Component**, you can be sure because of the `_beagleComponent_` attribute. Beagle comes with a lot of useful components (you can navigate through them [in the components section]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, it is called **Custom Components**, but save that for later. The example uses a simple and common component named [Container]({{< ref path="api/components/layout/container.md" >}}), and it allows you to *group together* `children` components.
-
-```json
-{
-  "_beagleComponent_": "beagle:container",
-  "style": {...},
   "children": [
-    { 
+    {
       "_beagleComponent_": "beagle:image",
       ...
     },
-    { 
+    {
       "_beagleComponent_": "beagle:text",
       ...
     },
-    { 
+    {
       "_beagleComponent_": "beagle:button",
       ...
     }
@@ -141,12 +132,10 @@ This is a **Component**, you can be sure because of the `_beagleComponent_` attr
 }
 ```
 
-> There are other components with the *children* attribute (sometimes just *child*) like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are used to **compose view hierarchies**.
+To Beagle, every structure that contains the `_beagleComponent_` attribute will be interpreted as a **Component**. The first one is a simple and common component named [Container]({{< ref path="api/components/layout/container.md" >}}), which allows you to *group together* `children` components. It has 3 children: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes to customize their rendering, and you can see all available attributes in each component's API documentation.
 
-In this example, there are 3 components inside the *Container*: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), and [Button]({{< ref path="api/components/ui/button.md" >}}). Each one have different attributes to customize their rendering, and you can see all available attributes in each component's API documentation.
-
-The *Image* component, for example, has an attribute named `path` that can receive `remote` or `local` paths to the image data.
-Check out below, we used the `remote` image by providing a `url` which Beagle will use to make a network request when the component gets rendered:
+The *Image* component, for example, has an attribute named `path` that especifies where to retrieve image data, it can be `remote` or `local`.
+Check out below, we used a `remote` path by providing a `url` which Beagle will use to make a network request when the component gets rendered:
 
 ```json
 {
@@ -160,6 +149,10 @@ Check out below, we used the `remote` image by providing a `url` which Beagle wi
 ```
 
 > You can have full control of the network request triggered by this remote image. You just need to configure your own *Network Layer* as a *Beagle Dependency*. To better understand how to do that, or how to configure other Beagle Dependencies, you can check the [Customization section]({{< ref path="resources/customization/_index.md" >}}).
+
+Beagle comes with a lot of useful components, you can navigate through all them in [the components section]({{< ref path="api/components/_index.md" >}}). You can also define your own components, which are called [Custom Components]({{< ref path="resources/customization/_index.md" >}}), but save that for later.
+
+> The *children* attribute (sometimes just *child*) is present in other components like [Screen]({{< ref path="api/screen/_index.md" >}}) and [ListView]({{< ref path="api/components/layout/listview.md" >}}), and they are also used to **compose view hierarchies**.
 
 ### Styling
 
@@ -186,7 +179,7 @@ Let's take a closer look into the `style` attribute, which describes how to posi
 }
 ```
 
-Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by changing the `flexDirection` attribute to **`ROW`** in Playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in the backend, and it will be reflected *immediately* in the frontend – even on mobile platforms, you don't need store updates.
+Most components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can experience that by changing the `flexDirection` attribute to **`ROW`** in the Playground, and you will see the same views positioned horizontally. In your real application, you can deploy this exact change in the backend, and it will be reflected *immediately* in the frontend – even on mobile platforms, you don't need store updates.
 
 > Many tools built in-house for Server Driven UI don't allow this kind of power over a UI positioning and this comes out of the box with Beagle.
 
@@ -194,7 +187,7 @@ In the example's *Container*, we are using 3 styling attributes: `flex`, `size`,
 
 #### Flex
 
-The `flex` attribute allows you to **use the same Layout Engine on different platforms**. This can be a huge win for your team because all platforms will be positioning views according to the same rules, and you won't need to "duplicate" layout logic for each platform.
+The `flex` attribute allows you to **use the same Layout Engine on different platforms**. This can be a huge win for your team because all platforms will position views according to the same rules, and you won't need to "duplicate" layout logic for each platform.
 
 - If you have experience with web development, you probably already know how to use `flex`, since it is used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this, Beagle uses a library called [**Yoga**](https://yogalayout.com), a cross-platform library developed in C++ by Facebook, and also used in other projects (e.g: React Native).
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -14,16 +14,16 @@ Beagle is an **open source framework** that helps developers implement **Server-
 
 By using Beagle, developers can:
 
+{{% alert color="success" %}}
 - **Rapidly change an application layout, data, navigation flow, or even logic**, just by changing code in your backend
 - **Be more independent of mobile stores** (App Store and Play Store), since most changes won't need an app update
-- **Have more confidence that their application behaves similar on different platforms**, since more code will be shared and standarized between backend and frontend
+- **Have more confidence that applications behave similar on different platforms**, since more code will be shared and standarized between backend and frontend
 - **Easily test new business hipothesis or make important fixes on live applications** to rapidly improve users experience and receive feedbacks
+{{% /alert %}}
 
 ## How does Beagle work?
 
-### Simple Example
-
-Here we will show you a simple screen declared via Beagle, containing just texts, images, and some layout and style configurations:
+The best way to understand how Beagle works is to see it in action. Here, we will show you a simple screen declared via Beagle containing just texts, images, and some layout and style configurations. At the end of this section, you will be familiar with Beagle's building blocks and most common features.
 
 <!-- json-playground:overview-simple-example.json
 {
@@ -82,7 +82,7 @@ Here we will show you a simple screen declared via Beagle, containing just texts
 
 {{% playground file="overview-simple-example.json" language="en" %}}
 
-As you can see on the left side, we are declaring our screen with JSON. You can think of that JSON as what your backend provides to your frontend via a HTTP response. Frontend will then interpret it, and properly render it on the platform's screen (as you can see in the right side). Beagle provides libraries on the backend and frontend to completely handle this workflow for you.
+As you can see on the left side, we are declaring our screen with JSON. You can think of that JSON as what your backend provides to your frontend via a HTTP response. Frontend will then interpret it, and properly render it on the platform's screen (as you can see in the right side). Beagle provides libraries on both backend and frontend to completely handle this workflow for you.
 
 Just to clarify, we are using JSON here because it is the most straightforward way to use Beagle, but it's not the most productive and scalable. We actually have a "language" (DSL in Kotlin) that you should use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
 
@@ -90,7 +90,7 @@ Also, you can see which frontend platforms we support [here](#platforms-and-vers
 
 > Throughout our documentation, you will see examples which use this tool we call **Playground**. By using it, you can quickly see how Beagle work in real life. You can, as well, edit the code on the left, and select different platforms to run your code on. To better understand how to use this tool, you can check this [section]({{< ref path="playground/_index.md" >}}).
 
-#### Components
+### Components
 
 Now, let's take a closer look inside this JSON, so you can better understand Beagle's capabilites. The first thing to notice is this structure:
 
@@ -102,15 +102,57 @@ Now, let's take a closer look inside this JSON, so you can better understand Bea
 }
 ```
 
-This is what we call a **Component**, and you can visualize that due to the property `_beagleComponent_`. Beagle comes with a bunch of useful components (you can navigate through them later [here]({{< ref path="api/components/_index.md" >}}), and you can also define your own components, which we call **Custom Components**, but that's a later topic. This one is a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), it allows you to group together other components, which are being described inside the property `children`.
+This is what we call a **Component**, and you can ensure that due to the attribute `_beagleComponent_`. Beagle comes with a bunch of useful components (you can navigate through them later [here]({{< ref path="api/components/_index.md" >}})), and you can also define your own components, which we call **Custom Components**, but that's a later topic. This one is a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), it allows you to *group together* those components inside attribute `children`.
 
-> There are other components with *children* property (or sometimes just *child*) like [Screen](api/screen/_index.md) and [ListView](api/components/layout/listview.md), and they are used to compose view hierarchies.
+There are other components with the *children* attribute (or sometimes just *child*) like [Screen](api/screen/_index.md) and [ListView](api/components/layout/listview.md), and they are usually used to **compose view hierarchies**. In this example, we have 3 other components inside *Container*: [Text](api/components/ui/text.md), [Image](api/components/ui/image/_index.md), and [Button](api/components/ui/button.md). Each one have different attributes you can use to customize their rendering, and you can see all these attributes in their documentation.
 
-Finally, there is the `style` property, which describes how to position and layout this component and its children. Most of components have this property, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can see this power by chaging the `flexDirection` property to `ROW` inside the playground, and you will see the same views positioned horizontally. In a real application, you could deploy this exact change in your backend, and they would be *immediately* reflected in your frontend – even on mobile platforms, without needing mobile stores update.
+The *Image* component, for example, has this attribute named `path` that can receive `remote` or `local` paths to the image data. Here we use a `remote` image by providing an `url` which Beagle will use to request the image when the component gets rendered.
 
-> Many tools for Server Driven UI built in-house don't allow this kind of power over UI positioning, and this come out of the box with Beagle.
+```json
+{
+  "_beagleComponent_": "beagle:image",
+  "path": {
+    "_beagleImagePath_": "remote",
+    "url": "https://i.ibb.co/rvRN9kv/logo.png"
+  },
+  "style": {...}
+}
+```
 
-You can see all Style attributes that you can use [here]({{< ref path="api/widget.md#style-attributes" >}}).
+> You can have full control on the network request triggered by this remote image, you just need to configure your own Network Layer as a Beagle Dependency. Beagle have many configurable pieces like this, you can see more in [Customization](resources/customization/_index.md).
+
+### Styling
+
+Finally, let's take a closer look into the `style` attribute, which describes how to position and layout components and their children. Most of components have this attribute, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can see this power by chaging the `flexDirection` attribute to `ROW` inside the playground, and you will see the same views positioned horizontally. In a real application, you could deploy this exact change in your backend, and they would be *immediately* reflected in your frontend – even on mobile platforms, without needing mobile stores update.
+
+> Many tools built in-house for Server Driven UI don't allow this kind of power over UI positioning, and this come out of the box with Beagle.
+
+```json
+{
+  "_beagleComponent_": "beagle:container",
+  "style": {
+    "flex": {
+      "flexDirection": "COLUMN",
+      "alignItems": "CENTER",
+      "justifyContent": "CENTER"
+    },
+    "size": {
+      "height": {
+        "value": 100,
+        "type": "PERCENT"
+      }
+    },
+    "backgroundColor": "#FFF"
+  },
+  "children": [...]
+}
+```
+
+In our *Container*, we are using 3 styling attributes: `flex`, `size`, and `backgroundColor`. There are other options as well, you can see them all [here]({{< ref path="api/widget.md#style-attributes" >}}).
+
+The `flex` attribute is pretty important because it allows you to **use the same Layout Engine on different platforms**. Since all your platforms will be positioning views according to the same rules, and you don't need to "duplicate" the same layout logic for each platform, this can be a huge win for your team.
+
+If you are familiar with web development, you probably already know how to use `flex` because it's used as a cross-platform [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp). To accomplish this behind the scenes, we leverage a library called [**Yoga**](https://yogalayout.com), a cross-platform C++ library developed by Facebook and used in other projects (e.g: React Native). If you are not familiar with Flexbox, it takes some time to get used to it, but we bet you will really enjoy it due to its simplicity, power, and universality. [Our documentation](resources/components-positioning/_index.md), and [Yoga's own documentation](https://yogalayout.com/docs) can really help you to quickly understand it.
 
 ### Overview of Beagle's architecture
 

--- a/content/en/overview.md
+++ b/content/en/overview.md
@@ -25,13 +25,70 @@ By using Beagle, developers can:
 
 Here we will show you a simple screen declared via Beagle, containing just texts, images, and some layout and style configurations:
 
-{{% playground language="en" %}}
+<!-- json-playground:overview-simple-example.json
+{
+  "_beagleComponent_": "beagle:container",
+  "style": {
+    "flex": {
+      "flexDirection": "COLUMN",
+      "alignItems": "CENTER",
+      "justifyContent": "CENTER"
+    },
+    "size": {
+      "height": {
+        "value": 100,
+        "type": "PERCENT"
+      }
+    },
+    "backgroundColor": "#FFF"
+  },
+  "children": [
+    {
+      "_beagleComponent_": "beagle:image",
+      "path": {
+        "_beagleImagePath_": "remote",
+        "url": "https://i.ibb.co/rvRN9kv/logo.png"
+      },
+      "style": {
+        "size": {
+          "width": {
+            "value": 242,
+            "type": "REAL"
+          },
+          "height": {
+            "value": 225,
+            "type": "REAL"
+          }
+        }
+      }
+    },
+    {
+      "_beagleComponent_": "beagle:text",
+      "text": "Welcome to Beagle playground! \nUse the left panel to start coding!",
+      "textColor": "#000",
+      "alignment": "CENTER",
+      "style": {
+        "margin": {
+          "all": {
+            "value": 40,
+            "type": "REAL"
+          }
+        }
+      }
+    }
+  ]
+}
+-->
 
-As you can see on the left side, we are declaring our screen with JSON. You can think of that JSON as what your backend provides to your frontend via a service call. The frontend will then interpret it, and properly render it on the platform's screen (as you can see in the right side). Beagle provides libraries on the backend and frontend to completely handle this workflow for you.
+{{% playground file="overview-simple-example.json" language="en" %}}
+
+As you can see on the left side, we are declaring our screen with JSON. You can think of that JSON as what your backend provides to your frontend via a HTTP response. Frontend will then interpret it, and properly render it on the platform's screen (as you can see in the right side). Beagle provides libraries on the backend and frontend to completely handle this workflow for you.
 
 Just to clarify, we are using JSON here because it is the most straightforward way to use Beagle, but it's not the most productive and scalable. We actually have a "language" (DSL in Kotlin) that you should use in your backend to produce this same JSON in a more productive way – with autocomplete and other benefits.
 
-Throughout our documentation, you will see examples which use this tool we call **Playground**. By using it, you can quickly see how Beagle APIs work in real life. You can as well edit the code on the left, and run it on different platforms just by selecting it inside the playground. To better understand how to use this tool, you can go [here](playground/_index.md).
+Also, you can see which frontend platforms we support [here](#platforms-and-versions). They all render components **natively**, that is, if you want to use Beagle in a native mobile application on Android and iOS, our SDKs for these platforms will use native UIs (Android Views and UIKit, respectively), and you can even integrate your own native components to work with Beagle.
+
+> Throughout our documentation, you will see examples which use this tool we call **Playground**. By using it, you can quickly see how Beagle work in real life. You can, as well, edit the code on the left, and select different platforms to run your code on. To better understand how to use this tool, you can check this [section]({{< ref path="playground/_index.md" >}}).
 
 #### Components
 
@@ -40,12 +97,20 @@ Now, let's take a closer look inside this JSON, so you can better understand Bea
 ```json
 {
   "_beagleComponent_": "beagle:container",
-  "style": {},
-  "children": []
+  "style": {...},
+  "children": [...]
 }
 ```
 
-This is what we call a **Component**, and you can visualize that due to the presence of `_beagleComponent_` property. Beagle comes with a bunch of useful components (you can navigate through them later [here](api/components/_index.md)), and you can also define your own components, we call that **Custom Components**, but that's a later topic. This one is a really basic and important component named [Container](api/components/layout/container.md), it allows you to group other components. That's why it has a property named `children`
+This is what we call a **Component**, and you can visualize that due to the property `_beagleComponent_`. Beagle comes with a bunch of useful components (you can navigate through them later [here]({{< ref path="api/components/_index.md" >}}), and you can also define your own components, which we call **Custom Components**, but that's a later topic. This one is a basic and important component named [Container]({{< ref path="api/components/layout/container.md" >}}), it allows you to group together other components, which are being described inside the property `children`.
+
+> There are other components with *children* property (or sometimes just *child*) like [Screen](api/screen/_index.md) and [ListView](api/components/layout/listview.md), and they are used to compose view hierarchies.
+
+Finally, there is the `style` property, which describes how to position and layout this component and its children. Most of components have this property, and it's responsible for an important Beagle feature: **developers have control *through backend* on UI positioning**. You can see this power by chaging the `flexDirection` property to `ROW` inside the playground, and you will see the same views positioned horizontally. In a real application, you could deploy this exact change in your backend, and they would be *immediately* reflected in your frontend – even on mobile platforms, without needing mobile stores update.
+
+> Many tools for Server Driven UI built in-house don't allow this kind of power over UI positioning, and this come out of the box with Beagle.
+
+You can see all Style attributes that you can use [here]({{< ref path="api/widget.md#style-attributes" >}}).
 
 ### Overview of Beagle's architecture
 
@@ -65,6 +130,8 @@ Beagle has different libraries/frameworks for each supported platform, in the fo
 - **Android:** [![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android)](https://mvnrepository.com/artifact/br.com.zup.beagle/android)
 - **iOS:** [![badge](https://img.shields.io/cocoapods/v/Beagle)](https://cocoapods.org/pods/Beagle)
 - **React Native:** [![react native badge](https://img.shields.io/npm/v/@zup-it/beagle-react-native?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react-native)
+- **Flutter:** *Being developed in this [folder](https://github.com/ZupIT/beagle/tree/master/flutter)*
+- **SwiftUI and Compose:** we will try to support them in the future
 
 **Web:**
 

--- a/content/pt/overview.md
+++ b/content/pt/overview.md
@@ -93,18 +93,19 @@ A melhor maneira de entender o Beagle é vê-lo em ação. Aqui, mostraremos uma
 
 {{% playground file="overview-simple-example.json" %}}
 
-> Ao longo da documentação, você verá exemplos - como o acima - que usam uma ferramenta chamada **Playground**. Ao usá-la, você pode:
+> Ao longo da documentação, você verá exemplos - como o acima - que usam uma ferramenta que fizemos chamada **Playground**. Ao usá-la, você pode:
 >
 > - Ver rapidamente como o Beagle funciona;
-> - Editar o código à esquerda e executá-lo para ver as mudanças visuais;
+> - Editar o código à esquerda, executá-lo, e observar o resultado;
 > - Selecionar plataformas diferentes para executar seu código.
+>
 > Para obter mais informações sobre esta ferramenta, consulte a [seção Playground]({{< ref path="playground/_index.md" >}}).
 
-Como você pode ver ao lado esquerdo, estamos declarando nossa tela com JSON. Você pode supor que esse JSON é o que o seu backend fornece ao frontend por meio de uma resposta HTTP. O frontend irá interpretá-lo e renderizá-lo corretamente na tela da plataforma (como você pode ver ao lado direito). O Beagle fornece bibliotecas no backend e frontend para lidar completamente com esse fluxo de trabalho para você.
+Como você pode ver ao lado esquerdo, estamos declarando nossa tela com JSON. Esse JSON seria o que o seu backend fornece ao frontend por meio de uma resposta HTTP. O frontend irá interpretá-lo e renderizá-lo corretamente na tela da plataforma (como no lado direito). O Beagle fornece bibliotecas no backend e frontend que lidam com esse fluxo para você.
 
-Só para deixar claro, neste exemplo, estamos usando JSON porque é a maneira mais direta de usar o Beagle, mas não é a mais produtiva e escalável. Na verdade, o Beagle tem uma "linguagem" (DSL em Kotlin) que você deve usar em seu backend para produzir esse mesmo JSON de uma maneira mais produtiva - com autocomplete e outros benefícios.
+Nos exemplos, utilizamos JSON porque é a maneira mais direta de se usar o Beagle. No entanto, o Beagle também possui uma "linguagem" (DSL em Kotlin) que você pode usar em seu backend para produzir esse mesmo JSON de uma maneira mais produtiva – com autocomplete e outros benefícios.
 
-Verifique quais plataformas de frontend o Beagle suporta [na seção de plataformas e versões](#plataformas-e-versões). Todas renderizam componentes **nativamente**, por exemplo, se você usar o Beagle em um aplicativo móvel nativo Android ou iOS, as bibliotecas para essas plataformas usarão UIs nativas (Android Views e UIKit, respectivamente), e você pode até integrar seus próprios componentes nativos para trabalhar com o Beagle.
+Verifique quais plataformas frontend o Beagle suporta na [seção de plataformas e versões](#plataformas-e-versões). Todas renderizam componentes **nativamente**, ou seja, se você usar o Beagle em um aplicativo móvel nativo Android ou iOS, as bibliotecas para essas plataformas usarão UIs nativas (Android Views e UIKit, respectivamente), e você pode até integrar seus próprios componentes nativos para funcionarem com o Beagle.
 
 ### Componentes
 
@@ -114,26 +115,16 @@ Agora, vamos dar uma olhada mais de perto nesse JSON, para que você possa enten
 {
   "_beagleComponent_": "beagle:container",
   "style": {...},
-  "children": [...]
-}
-```
-
-Este é um **Component**, você pode ter certeza por causa do atributo `_beagleComponent_`. O Beagle vem com muitos componentes úteis (você pode navegar por eles [na seção de componentes]({{< ref path = "api/components/_index.md" >}})) e também pode definir seus próprios componentes, chamados de **Custom Components**, mas guarde isso para depois. O exemplo usa um componente simples e comum chamado [Container]({{< ref path = "api/components/layout/container.md" >}}) e permite que você *agrupe* os componentes `children`.
-
-```json
-{
-  "_beagleComponent_": "beagle:container",
-  "style": {...},
   "children": [
-    { 
+    {
       "_beagleComponent_": "beagle:image",
       ...
     },
-    { 
+    {
       "_beagleComponent_": "beagle:text",
       ...
     },
-    { 
+    {
       "_beagleComponent_": "beagle:button",
       ...
     }
@@ -141,12 +132,10 @@ Este é um **Component**, você pode ter certeza por causa do atributo `_beagleC
 }
 ```
 
-> Existem outros componentes com o atributo *children* (às vezes apenas *child*) como [Screen]({{< ref path="api/screen/_index.md" >}}) e [ListView]({{< ref path="api/components/layout/listview.md" >}}), e eles são usados para **compor hierarquias de views**.
+Para o Beagle, toda estrutura que contém o atributo `_beagleComponent_` será interpretada como um **Component**. O primeiro é um componente simples e comum chamado [Container]({{< ref path="api/components/layout/container.md" >}}), que permite *agrupar* componentes `children`. Ele possui 3 filhos: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), e [Button]({{< ref path="api/components/ui/button.md" >}}). Cada um tem atributos diferentes para customizar sua renderização, e você pode ver todos os atributos disponíveis em suas respectivas documentações de API.
 
-Neste exemplo, existem 3 componentes dentro do *Container*: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), e [Button]({{< ref path="api/components/ui/button.md" >}}). Cada um tem atributos diferentes para customizar sua renderização, e você pode ver todos os atributos disponíveis em suas respectivas documentações de API.
-
-O componente *Image*, por exemplo, tem um atributo chamado `path` que pode receber caminhos `remote` ou `local` para os dados da imagem.
-Confira abaixo, nós usamos a imagem `remote` fornecendo um `url` que o Beagle usará para fazer uma solicitação de rede quando o componente for renderizado:
+O componente *Image*, por exemplo, tem um atributo chamado `path` para saber onde estão os dados da imagem, que pode ser `remote` ou `local`.
+Confira abaixo, nós usamos o path `remote` fornecendo uma `url` que o Beagle usará para criar uma requisição remota quando o componente for renderizado:
 
 ```json
 {
@@ -159,7 +148,11 @@ Confira abaixo, nós usamos a imagem `remote` fornecendo um `url` que o Beagle u
 }
 ```
 
-> Você pode ter controle total da solicitação de rede acionada por esta imagem remota. Você só precisa configurar sua própria *Camada de Rede* como uma *Dependência do Beagle*. Para entender melhor como fazer isso, ou como configurar outras Dependências do Beagle, você pode verificar a [seção de Customização]({{< ref path="resources/customization/_index.md" >}}).
+> Você pode ter controle total da requisição acionada por esta imagem remota. Você só precisa configurar sua própria *Camada de Rede* como uma *Dependência do Beagle*. Para entender melhor como fazer isso, ou como configurar outras Dependências do Beagle, você pode verificar a [seção de Customização]({{< ref path="resources/customization/_index.md" >}}).
+
+O Beagle já vem com vários componentes úteis, você pode navegar por todos eles na [seção de componentes]({{< ref path = "api/components/_index.md" >}}). Você também pode definir seus próprios componentes, chamados de [Custom Components]({{< ref path="resources/customization/_index.md" >}}), mas guarde isso para depois.
+
+> O atributo *children* (às vezes apenas *child*) está presente em outros components como [Screen]({{< ref path="api/screen/_index.md" >}}) e [ListView]({{< ref path="api/components/layout/listview.md" >}}), e eles também são usados para **compor hierarquias de views**.
 
 ### Style
 

--- a/content/pt/overview.md
+++ b/content/pt/overview.md
@@ -23,7 +23,13 @@ Ao utilizar o Beagle, desenvolvedores podem:
 
 ## Como o Beagle funciona?
 
-A melhor maneira de entender o Beagle é vê-lo em ação. Aqui, mostraremos uma tela simples declarada via Beagle, contendo apenas textos, imagens e algumas configurações de estilo. No final desta seção, você estará familiarizado com os recursos mais comuns do Beagle.
+A melhor maneira de entender o Beagle é vê-lo em ação. Por isso, mostraremos **como construir uma tela simples com o Beagle**.
+
+Comentaremos sobre cada pedaço da tela (texto, imagem, botão, e configurações de estilo), e deixaremos links para outras partes da documentação que entram em mais detalhes. Ao final dessa página, você se familiarizará com os recursos mais comuns do Beagle.
+
+> Os links para outras páginas são apenas para informações mais detalhadas, não há necessidade de acessá-los imediatamente.
+
+Dito isso, aqui está a tela que discutiremos:
 
 <!-- json-playground:overview-simple-example.json
 {
@@ -101,7 +107,7 @@ A melhor maneira de entender o Beagle é vê-lo em ação. Aqui, mostraremos uma
 >
 > Para obter mais informações sobre esta ferramenta, consulte a [seção Playground]({{< ref path="playground/_index.md" >}}).
 
-Como você pode ver ao lado esquerdo, estamos declarando nossa tela com JSON. Esse JSON seria o que o seu backend fornece ao frontend por meio de uma resposta HTTP. O frontend irá interpretá-lo e renderizá-lo corretamente na tela da plataforma (como no lado direito). O Beagle fornece bibliotecas no backend e frontend que lidam com esse fluxo para você.
+Como você pode ver ao lado esquerdo, estamos declarando nossa tela com JSON. Esse JSON seria o quê o backend fornece ao frontend por meio de uma resposta HTTP. O frontend, então, irá interpretá-lo e renderizá-lo corretamente na tela da plataforma (como no lado direito). O Beagle fornece bibliotecas no backend e frontend que lidam com esse fluxo para você.
 
 Nos exemplos, utilizamos JSON porque é a maneira mais direta de se usar o Beagle. No entanto, o Beagle também possui uma "linguagem" (DSL em Kotlin) que você pode usar em seu backend para produzir esse mesmo JSON de uma maneira mais produtiva – com autocomplete e outros benefícios.
 
@@ -150,9 +156,7 @@ Confira abaixo, nós usamos o path `remote` fornecendo uma `url` que o Beagle us
 
 > Você pode ter controle total da requisição acionada por esta imagem remota. Você só precisa configurar sua própria *Camada de Rede* como uma *Dependência do Beagle*. Para entender melhor como fazer isso, ou como configurar outras Dependências do Beagle, você pode verificar a [seção de Customização]({{< ref path="resources/customization/_index.md" >}}).
 
-O Beagle já vem com vários componentes úteis, você pode navegar por todos eles na [seção de componentes]({{< ref path = "api/components/_index.md" >}}). Você também pode definir seus próprios componentes, chamados de [Custom Components]({{< ref path="resources/customization/_index.md" >}}), mas guarde isso para depois.
-
-> O atributo *children* (às vezes apenas *child*) está presente em outros components como [Screen]({{< ref path="api/screen/_index.md" >}}) e [ListView]({{< ref path="api/components/layout/listview.md" >}}), e eles também são usados para **compor hierarquias de views**.
+O Beagle já vem com vários componentes úteis, você pode navegar por todos eles na [seção de componentes]({{< ref path = "api/components/_index.md" >}}). Há outros componentes, por exemplo, que possuem o atributo *children* (às vezes apenas *child*) como o [Screen]({{< ref path="api/screen/_index.md" >}}) e o [ListView]({{< ref path="api/components/layout/listview.md" >}}), e eles são usados para **compor hierarquias de views** como o *Container*. Também é possível definir seus próprios componentes, chamados de [Custom Components]({{< ref path="resources/customization/_index.md" >}}), e utilizá-los de forma muito similar a um componente que já vem no Beagle.
 
 ### Style
 

--- a/content/pt/overview.md
+++ b/content/pt/overview.md
@@ -10,68 +10,276 @@
 
 ## O que é o Beagle?
 
-O Beagle é um **framework open source** de desenvolvimento cross-platform pautado no paradigma de implementação de **Server-Driven UI.**
+Beagle é uma **ferramenta de código aberto** que ajuda os desenvolvedores a implementar **Server-Driven UI** que funcione em **múltiplas plataformas**.
 
-{{% alert color="warning" %}}
-O principal ganho da ferramenta é permitir que as equipes façam **alterações de layout e de dados direto em aplicações nativas mobile e/ou web** modificando apenas o código no backend.
-{{% /alert %}}
-
-Dessa forma, é possível criar, testar e atualizar rapidamente os componentes de aplicações nativas sem a necessidade de passar pela loja \(App Store ou Play Store\).
-
-### Versionamento <a id="version"></a>
-
-As versões do Beagle seguem o conceito de [**versionamento semântico**](https://semver.org/). A documentação, em si, é versionada de acordo com a versão major \(maior\) do Beagle, ou seja, com a versão principal. Entre as plataformas, a compatibilidade de features é pela versão minor. Por exemplo, é possível usar a 1.0.0 no backend com a 1.0.1 no Android, a 1.0.2 no iOS e a 1.0.3 no web react.
-
-{{% alert color="info" %}}
-As versões de **release atuais** do Beagle são:
-
-- **Android:**[![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android)](https://mvnrepository.com/artifact/br.com.zup.beagle/android)
-- **iOS:**[![badge](https://img.shields.io/cocoapods/v/Beagle)]()
-- **WEB:**
-  - **Angular:**[![badge](https://img.shields.io/npm/v/@zup-it/beagle-angular?logo=Angular)](https://github.com/ZupIT/beagle-web-angular)
-  - **React:**[![badge](https://img.shields.io/npm/v/@zup-it/beagle-react?logo=React)](https://github.com/ZupIT/beagle-web-react)
-- **React Native:**[![react native badge](https://img.shields.io/npm/v/@zup-it/beagle-react-native?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react-native)
-- **Backend:**[![back](https://camo.githubusercontent.com/27998a386042ecb2cae7b9f09ae159bd07c935bd/68747470733a2f2f696d672e736869656c64732e696f2f6d6176656e2d63656e7472616c2f762f62722e636f6d2e7a75702e626561676c652f6672616d65776f726b)](https://mvnrepository.com/artifact/br.com.zup.beagle/framework)
-  {{% /alert %}}
-
-Algumas definições nessa documentação existem apenas em algumas minors ou patches específicas. Segue a legenda usada para denotar esses casos:
-
-- `x.y.z`: designa uma definição exclusiva da versão x.y.z;
-- `>=x.y.z`: designa uma definição existente a partir da versão x.y.z;
-- `<=x.y.z`: designa uma definição existente até a versão x.y.z.
-
-## Como funciona o Beagle?
-
-A ferramenta atua como um facilitador do **BFF** \([**Backend For Frontend**]({{< ref path="/key-concepts#backend-for-frontend" lang="pt" >}})\) Isso significa que o Beagle, a partir de uma biblioteca de componentes definidos no [**Design System**]({{< ref path="/key-concepts#design-system" lang="pt" >}}) da aplicação Android, iOS ou Web, faz a alteração visual e comportamental delas ao retornar um arquivo JSON que indica o que e onde deve ser renderizado cada componente e qual a ação que vão executar.
-
-![](/shared/beaglemobileback.png)
-
-O motivo pelo qual o Beagle consegue fazer essa alteração do frontend a partir do backend é porque sua arquitetura está estruturada em [**Server-Driven UI**]({{< ref path="/key-concepts#server-driven-ui" lang="pt" >}}), onde o BFF constrói os dados, componentes e ações presentes na tela de forma declarativa e os encaminha no formato JSON, enquanto o front o desserializa, renderiza os componentes visuais de forma nativa além de executar e atribuir as ações presentes em cada um deles.
-
-### Pilares do Beagle
-
-Por se tratar de uma ferramenta pautada em Server-Driven UI, os objetos JSON configurados para rodar na sua aplicação podem ser divididos em 3 pilares básicos:
-
-- Conteúdo
-- Estrutura Visual
-- Flow \(ou Ações\)
-
-Depois de definido no frontend e no backend como será a estrutura visual da aplicação com os componentes e ações customizados, bem como como eles poderão ser alterados, o BFF estará apto a se comunicar com o front.
-
-Dessa forma, novas features, fluxos, customizações e combinações de componentes visuais podem ser testados sem a necessidade de publicar atualizações no aplicativo, otimizando testes de tipo A/B.
-
-![](/shared/images/beaglecomp.png)
-
-## Por que usar o Beagle?
+Ao utilizar o Beagle, desenvolvedores podem:
 
 {{% alert color="success" %}}
-O Beagle foi criado com objetivo de **otimizar tempo e recurso das equipes** de desenvolvimento, design e negócios para publicar e manter atualizados seus aplicativos sem a necessidade de passar por App Store ou Play Store e, ainda assim, respeitar o Design System da aplicação.
+- **Rapidamente alterar o layout, dados, fluxo de navegação, ou até mesmo lógica**, apenas alterando código no backend.
+- **Ser mais independentes das lojas mobile**, como App Store e Play Store, porque a maioria das mudanças não precisarão de uma atualização no aplicativo.
+- **Ter mais confiança de que aplicações se comportarão de forma semelhante em plataformas diferentes**, pois o código será compartilhado e padronizado entre backend e frontend.
+- **Testar facilmente novas hipóteses de negócio ou fazer correções em tempo real nas aplicações** para melhorar a experiência dos usuários e receber feedback.
 {{% /alert %}}
 
-Sendo assim, as principais vantagens que o Beagle traz para seu projeto são:
+## Como o Beagle funciona?
 
-- **Maior flexibilidade de trabalho** entre desenvolvedores frontend, backend e UI/UX designers no momento de realizar alterações pontuais.
-- **Facilidade de manutenção do app**, além de possibilitar a realização constante de testes para melhoria da sua aplicação.
-- **Menos duplicação de códigos**, pois todo o consumo das APIs, fluxos e regras estarão em um único lugar, o BFF.
+A melhor maneira de entender o Beagle é vê-lo em ação. Aqui, mostraremos uma tela simples declarada via Beagle, contendo apenas textos, imagens e algumas configurações de estilo. No final desta seção, você estará familiarizado com os recursos mais comuns do Beagle.
 
-Outro ganho fundamental que o Beagle traz, é a possibilidade de **reduzir o tempo de feedback do usuário**, já que as mudanças são rapidamente testadas e validadas.
+<!-- json-playground:overview-simple-example.json
+{
+  "_beagleComponent_": "beagle:container",
+  "style": {
+    "flex": {
+      "flexDirection": "COLUMN",
+      "alignItems": "CENTER",
+      "justifyContent": "CENTER"
+    },
+    "size": {
+      "height": {
+        "value": 100,
+        "type": "PERCENT"
+      }
+    },
+    "backgroundColor": "#FFF"
+  },
+  "children": [
+    {
+      "_beagleComponent_": "beagle:image",
+      "path": {
+        "_beagleImagePath_": "remote",
+        "url": "https://i.ibb.co/rvRN9kv/logo.png"
+      },
+      "style": {
+        "size": {
+          "width": {
+            "value": 242,
+            "type": "REAL"
+          },
+          "height": {
+            "value": 225,
+            "type": "REAL"
+          }
+        }
+      }
+    },
+    {
+      "_beagleComponent_": "beagle:text",
+      "text": "Welcome to Beagle playground! \nUse the left panel to start coding!",
+      "textColor": "#000",
+      "alignment": "CENTER",
+      "style": {
+        "margin": {
+          "all": {
+            "value": 40,
+            "type": "REAL"
+          }
+        }
+      }
+    },
+    {
+      "_beagleComponent_": "beagle:button",
+      "text": "Click here to show an Alert",
+      "onPress": [
+        {
+          "_beagleAction_": "beagle:alert",
+          "title": "My Title",
+          "message": "Alert message"
+        }
+      ]
+    }
+  ]
+}
+-->
+
+{{% playground file="overview-simple-example.json" %}}
+
+> Ao longo da documentação, você verá exemplos - como o acima - que usam uma ferramenta chamada **Playground**. Ao usá-la, você pode:
+>
+> - Ver rapidamente como o Beagle funciona;
+> - Editar o código à esquerda e executá-lo para ver as mudanças visuais;
+> - Selecionar plataformas diferentes para executar seu código.
+> Para obter mais informações sobre esta ferramenta, consulte a [seção Playground]({{< ref path="playground/_index.md" >}}).
+
+Como você pode ver ao lado esquerdo, estamos declarando nossa tela com JSON. Você pode supor que esse JSON é o que o seu backend fornece ao frontend por meio de uma resposta HTTP. O frontend irá interpretá-lo e renderizá-lo corretamente na tela da plataforma (como você pode ver ao lado direito). O Beagle fornece bibliotecas no backend e frontend para lidar completamente com esse fluxo de trabalho para você.
+
+Só para deixar claro, neste exemplo, estamos usando JSON porque é a maneira mais direta de usar o Beagle, mas não é a mais produtiva e escalável. Na verdade, o Beagle tem uma "linguagem" (DSL em Kotlin) que você deve usar em seu backend para produzir esse mesmo JSON de uma maneira mais produtiva - com autocomplete e outros benefícios.
+
+Verifique quais plataformas de frontend o Beagle suporta [na seção de plataformas e versões](#plataformas-e-versões). Todas renderizam componentes **nativamente**, por exemplo, se você usar o Beagle em um aplicativo móvel nativo Android ou iOS, as bibliotecas para essas plataformas usarão UIs nativas (Android Views e UIKit, respectivamente), e você pode até integrar seus próprios componentes nativos para trabalhar com o Beagle.
+
+### Componentes
+
+Agora, vamos dar uma olhada mais de perto nesse JSON, para que você possa entender melhor os recursos do Beagle. A primeira coisa a notar é a sua estrutura:
+
+```json
+{
+  "_beagleComponent_": "beagle:container",
+  "style": {...},
+  "children": [...]
+}
+```
+
+Este é um **Component**, você pode ter certeza por causa do atributo `_beagleComponent_`. O Beagle vem com muitos componentes úteis (você pode navegar por eles [na seção de componentes]({{< ref path = "api/components/_index.md" >}})) e também pode definir seus próprios componentes, chamados de **Custom Components**, mas guarde isso para depois. O exemplo usa um componente simples e comum chamado [Container] ({{< ref path = "api/components/layout/container.md" >}}) e permite que você *agrupe* os componentes `children`.
+
+```json
+{
+  "_beagleComponent_": "beagle:container",
+  "style": {...},
+  "children": [
+    { 
+      "_beagleComponent_": "beagle:image",
+      ...
+    },
+    { 
+      "_beagleComponent_": "beagle:text",
+      ...
+    },
+    { 
+      "_beagleComponent_": "beagle:button",
+      ...
+    }
+  ]
+}
+```
+
+> Existem outros componentes com o atributo *children* (às vezes apenas *child*) como [Screen]({{< ref path="api/screen/_index.md" >}}) e [ListView]({{< ref path="api/components/layout/listview.md" >}}), e eles são usados para **compor hierarquias de views**.
+
+Neste exemplo, existem 3 componentes dentro do *Container*: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), e [Button]({{< ref path="api/components/ui/button.md" >}}). Cada um tem atributos diferentes para customizar sua renderização, e você pode ver todos os atributos disponíveis em suas respectivas documentações de API.
+
+The *Image* component, for example, has an attribute named `path` that can receive `remote` or `local` paths to the image data.
+Check out below, we used the `remote` image by providing a `url` which Beagle will use to make a network request when the component gets rendered:
+
+O componente *Image*, por exemplo, tem um atributo chamado `path` que pode receber caminhos `remote` ou `local` para os dados da imagem.
+Confira abaixo, nós usamos a imagem `remote` fornecendo um `url` que o Beagle usará para fazer uma solicitação de rede quando o componente for renderizado:
+
+```json
+{
+  "_beagleComponent_": "beagle:image",
+  "path": {
+    "_beagleImagePath_": "remote",
+    "url": "https://i.ibb.co/rvRN9kv/logo.png"
+  },
+  "style": {...}
+}
+```
+
+> Você pode ter controle total da solicitação de rede acionada por esta imagem remota. Você só precisa configurar sua própria *Camada de Rede* como uma *Dependência do Beagle*. Para entender melhor como fazer isso, ou como configurar outras Dependências do Beagle, você pode verificar a [seção de Customização]({{< ref path="resources/customization/_index.md" >}}).
+
+### Style
+
+Vamos dar uma olhada mais de perto no atributo `style`, que descreve como posicionar componentes e seus filhos:
+
+```json
+{
+  "_beagleComponent_": "beagle:container",
+  "style": {
+    "flex": {
+      "flexDirection": "COLUMN",
+      "alignItems": "CENTER",
+      "justifyContent": "CENTER"
+    },
+    "size": {
+      "height": {
+        "value": 100,
+        "type": "PERCENT"
+      }
+    },
+    "backgroundColor": "#FFF"
+  },
+  "children": [...]
+}
+```
+
+A maioria dos componentes tem esse atributo, que é responsável por uma feature importante do Beagle: **os desenvolvedores têm controle *via backend* no posicionamento de views**. Você pode experimentar isso alterando o atributo `flexDirection` para **`ROW`** no Playground, e você verá as mesmas views posicionadas horizontalmente. Em seu aplicativo real, você pode implantar essa mesma mudança no backend, e isso será refletido *imediatamente* no frontend – mesmo em plataformas móveis, você não precisa de atualizações nas lojas.
+
+> Muitas ferramentas desenvolvidas internamente para Server Driven UI não permitem esse tipo de poder sobre o posicionamento de views, e isso já vem pronto com o Beagle.
+
+No *Container* do exemplo, estamos usando 3 atributos de estilo: `flex`, `size` e `backgroundColor`. Existem outras opções também, você pode vê-las na [seção Style]({{< ref path="api/widget.md#style-attributes" >}}).
+
+#### Flex
+
+O atributo `flex` permite que você **use o mesmo Motor de Layout em diferentes plataformas**. Isso pode ser uma grande vantagem para a sua equipe,pois todas as plataformas posicionarão as views de acordo com as mesmas regras, e você não precisará "duplicar" a lógica de layout para cada plataforma.
+
+- Se você tem experiência com desenvolvimento web, provavelmente já sabe como usar o `flex`, pois ele é usado como um [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp) multiplataforma. Para obter esse resultado, o Beagle usa uma biblioteca chamada [Yoga](https://yogalayout.com), uma biblioteca multiplataform desenvolvida em C++ pelo Facebook, e também usada em outros projetos (por exemplo: React Native).
+
+- Se você não estiver familiarizado com o Flexbox, verifique [a seção de posicionamento]({{< ref path="resources/components-positioning/_index.md" >}}) e a [documentação do Yoga](https://yogalayout.com/docs) para obter mais detalhes.
+
+### Ações
+
+Finalmente, vamos falar sobre *Actions*, uma maneira de adicionar *dinamismo em tempo de execução* a um componente Beagle. No exemplo, há uma ação dentro de um botão:
+
+```json
+{
+  "_beagleComponent_": "beagle:button",
+  "text": "Click here to show an Alert",
+  "onPress": [
+    {
+      "_beagleAction_": "beagle:alert",
+      "title": "My Title",
+      "message": "Alert message"
+    }
+  ]
+}
+```
+
+O [componente Button]({{< ref path="api/components/ui/button.md" >}}) possui um atributo chamado `onPress` que pode receber uma lista de ações, as quais só serão executadas quando o botão for pressionado. Você pode ver todas as ações padrão do Beagle na [seção Actions]({{< ref path="api/actions/_index.md" >}}). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
+
+Esse exemplo usa uma [ação Alert]({{< ref path="api/actions/alert.md" >}}), o que resulta na exibição de um componente de alerta quando alguém toca o botão. Você pode fazer isso no *Playground* e ver você mesmo.
+
+Além de mostrar um alerta, você também pode utilizar ações para:
+
+- Naveguar para outra tela com uma [ação Navigate]({{< ref path="api/actions/navigate/_index.md" >}}).
+- Enviar uma requisição http com uma [ação SendRequest]({{< ref path="api/actions/sendrequest.md" >}}).
+- Adicionar novas views na hierarquia atual de views com uma [ação AddChildren]({{< ref path="api/actions/addchildren.md" >}}).
+
+Além disso, as ações são essenciais para se **criar telas complexas e dinâmicas**. Você pode ver mais sobre este tópico na [seção "Como fazer comunicação entre componentes"]({{< ref path="tutorials/how-to-make-communication-between-components.md" >}}).
+
+---
+
+## Conclusão e próximos passos
+
+Depois de ver as partes mais essenciais do Beagle, você está pronto para mergulhar em tópicos mais avançados:
+
+- Se quiser ver um exemplo mais complexo de um aplicativo que utiliza completamente o Beagle, você pode verificar [este repositório](https://github.com/ZupIT/beagle-adoption-demo). Ele possui um backend em Kotlin e frontends nativos para dispositivos móveis em Android e iOS.
+
+- Se você deseja integrar o Beagle em seu aplicativo existente, você pode seguir o [guia de instalação]({{< ref path="get-started/installing-beagle/_index.md" >}}) de cada plataforma, e depois verificar a [seção de usando o Beagle]({{< ref path="get-started/using-beagle/_index.md" >}}).
+
+- Se você deseja iniciar um novo projeto com o Beagle, você pode seguir o [guia de criação de um projeto do zero]({{< ref path="get-started/creating-a-project-from-scratch/_index.md" >}}).
+
+- Se você quiser saber mais sobre uma API específica, use a [seção API]({{< ref path="api/_index.md" >}}).
+
+- Se você não tiver certeza de como encontrar informações sobre um contexto específico, use o **campo de pesquisa no canto superior direito da tela** para pesquisar palavras em toda esta documentação.
+
+### Visão geral da arquitetura do Beagle
+
+![Uma visão geral da arquitetura do Beagle](/shared/beaglemobileback.png)
+
+---
+
+## Platformas e Versões
+
+O Beagle possui diferentes bibliotecas/frameworks para cada plataforma suportada, na lista a seguir você pode ver e acessar as versões mais recentes:
+
+{{% alert color="info" %}}
+**Backend Kotlin:** [![back](https://camo.githubusercontent.com/27998a386042ecb2cae7b9f09ae159bd07c935bd/68747470733a2f2f696d672e736869656c64732e696f2f6d6176656e2d63656e7472616c2f762f62722e636f6d2e7a75702e626561676c652f6672616d65776f726b)](https://mvnrepository.com/artifact/br.com.zup.beagle/framework)
+
+**Mobile**:
+
+- **Android:** [![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android)](https://mvnrepository.com/artifact/br.com.zup.beagle/android)
+- **iOS:** [![badge](https://img.shields.io/cocoapods/v/Beagle)](https://cocoapods.org/pods/Beagle)
+- **React Native:** [![react native badge](https://img.shields.io/npm/v/@zup-it/beagle-react-native?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react-native)
+- **Flutter:** *Em desenvolvimento, confira mais informações [nesta pasta](https://github.com/ZupIT/beagle/tree/master/flutter)*
+- **SwiftUI and Compose:** *vamos tentar suportá-los no futuro*
+
+**Web:**
+
+- **Angular:** [![badge](https://img.shields.io/npm/v/@zup-it/beagle-angular?logo=Angular)](https://www.npmjs.com/package/@zup-it/beagle-angular)
+- **React:** [![badge](https://img.shields.io/npm/v/@zup-it/beagle-react?logo=React)](https://www.npmjs.com/package/@zup-it/beagle-react)
+{{% /alert %}}
+
+### Entendendo os números da versão
+
+A versão do Beagle segue o padrão de [versionamento semântico](https://semver.org/).
+
+A *documentação* apenas possui versões com números até o **minor**, por exemplo: `1.2`. No entanto, algumas definições de versões minor anteriores ainda podem estar presentes, mesmo que não sejam mais válidas. Se for o caso, tentaremos informar as versões específicas dessas definições.
+
+Entre plataformas, é possível usar diferentes versões **patch**. Por exemplo, ter a versão `1.0.0` no backend com `1.0.1` no Android, `1.0.2` no iOS, e `1.0.3` na web React.

--- a/content/pt/overview.md
+++ b/content/pt/overview.md
@@ -277,6 +277,6 @@ O Beagle possui diferentes bibliotecas/frameworks para cada plataforma suportada
 
 A versão do Beagle segue o padrão de [versionamento semântico](https://semver.org/).
 
-A *documentação* apenas possui versões com números até o **minor**, por exemplo: `1.2`. No entanto, algumas definições de versões minor anteriores ainda podem estar presentes, mesmo que não sejam mais válidas. Se for o caso, tentaremos informar as versões específicas dessas definições.
+Entre plataformas, o último número (**patch**) costuma divergir, uma vez que alguns bugs ocorrem apenas em uma determinada plataforma. Assim, o seguinte exemplo é normal e esperado: ter a versão `1.0.0` no backend com `1.0.2` no Android, `1.0.0` no iOS, e `1.0.3` na web React.
 
-Entre plataformas, é possível usar diferentes versões **patch**. Por exemplo, ter a versão `1.0.0` no backend com `1.0.1` no Android, `1.0.2` no iOS, e `1.0.3` na web React.
+A *documentação* apenas possui versões com números até o **minor**, por exemplo: `1.2`. No entanto, algumas definições de versões minor anteriores ainda podem estar presentes, mesmo que não sejam mais válidas. Se for o caso, tentaremos informar as versões em que essas definições ainda são válidas.

--- a/content/pt/overview.md
+++ b/content/pt/overview.md
@@ -118,7 +118,7 @@ Agora, vamos dar uma olhada mais de perto nesse JSON, para que você possa enten
 }
 ```
 
-Este é um **Component**, você pode ter certeza por causa do atributo `_beagleComponent_`. O Beagle vem com muitos componentes úteis (você pode navegar por eles [na seção de componentes]({{< ref path = "api/components/_index.md" >}})) e também pode definir seus próprios componentes, chamados de **Custom Components**, mas guarde isso para depois. O exemplo usa um componente simples e comum chamado [Container] ({{< ref path = "api/components/layout/container.md" >}}) e permite que você *agrupe* os componentes `children`.
+Este é um **Component**, você pode ter certeza por causa do atributo `_beagleComponent_`. O Beagle vem com muitos componentes úteis (você pode navegar por eles [na seção de componentes]({{< ref path = "api/components/_index.md" >}})) e também pode definir seus próprios componentes, chamados de **Custom Components**, mas guarde isso para depois. O exemplo usa um componente simples e comum chamado [Container]({{< ref path = "api/components/layout/container.md" >}}) e permite que você *agrupe* os componentes `children`.
 
 ```json
 {
@@ -144,9 +144,6 @@ Este é um **Component**, você pode ter certeza por causa do atributo `_beagleC
 > Existem outros componentes com o atributo *children* (às vezes apenas *child*) como [Screen]({{< ref path="api/screen/_index.md" >}}) e [ListView]({{< ref path="api/components/layout/listview.md" >}}), e eles são usados para **compor hierarquias de views**.
 
 Neste exemplo, existem 3 componentes dentro do *Container*: [Image]({{< ref path="api/components/ui/image/_index.md" >}}), [Text]({{< ref path="api/components/ui/text.md" >}}), e [Button]({{< ref path="api/components/ui/button.md" >}}). Cada um tem atributos diferentes para customizar sua renderização, e você pode ver todos os atributos disponíveis em suas respectivas documentações de API.
-
-The *Image* component, for example, has an attribute named `path` that can receive `remote` or `local` paths to the image data.
-Check out below, we used the `remote` image by providing a `url` which Beagle will use to make a network request when the component gets rendered:
 
 O componente *Image*, por exemplo, tem um atributo chamado `path` que pode receber caminhos `remote` ou `local` para os dados da imagem.
 Confira abaixo, nós usamos a imagem `remote` fornecendo um `url` que o Beagle usará para fazer uma solicitação de rede quando o componente for renderizado:
@@ -197,9 +194,9 @@ No *Container* do exemplo, estamos usando 3 atributos de estilo: `flex`, `size` 
 
 #### Flex
 
-O atributo `flex` permite que você **use o mesmo Motor de Layout em diferentes plataformas**. Isso pode ser uma grande vantagem para a sua equipe,pois todas as plataformas posicionarão as views de acordo com as mesmas regras, e você não precisará "duplicar" a lógica de layout para cada plataforma.
+O atributo `flex` permite que você **use o mesmo Motor de Layout em diferentes plataformas**. Isso pode ser uma grande vantagem para o seu time, pois todas as plataformas posicionarão as views de acordo com as mesmas regras, e você não precisará "duplicar" a lógica de layout para cada plataforma.
 
-- Se você tem experiência com desenvolvimento web, provavelmente já sabe como usar o `flex`, pois ele é usado como um [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp) multiplataforma. Para obter esse resultado, o Beagle usa uma biblioteca chamada [Yoga](https://yogalayout.com), uma biblioteca multiplataform desenvolvida em C++ pelo Facebook, e também usada em outros projetos (por exemplo: React Native).
+- Se você tem experiência com desenvolvimento web, provavelmente já sabe como usar o `flex`, pois ele é usado como um [CSS Flexbox](https://www.w3schools.com/css/css3_flexbox.asp) multiplataforma. Para obter esse resultado, o Beagle usa uma biblioteca chamada [Yoga](https://yogalayout.com), biblioteca multiplataform desenvolvida em C++ pelo Facebook, e também usada em outros projetos (por exemplo: React Native).
 
 - Se você não estiver familiarizado com o Flexbox, verifique [a seção de posicionamento]({{< ref path="resources/components-positioning/_index.md" >}}) e a [documentação do Yoga](https://yogalayout.com/docs) para obter mais detalhes.
 
@@ -221,7 +218,7 @@ Finalmente, vamos falar sobre *Actions*, uma maneira de adicionar *dinamismo em 
 }
 ```
 
-O [componente Button]({{< ref path="api/components/ui/button.md" >}}) possui um atributo chamado `onPress` que pode receber uma lista de ações, as quais só serão executadas quando o botão for pressionado. Você pode ver todas as ações padrão do Beagle na [seção Actions]({{< ref path="api/actions/_index.md" >}}). But it's also possible to create your own actions (a proccess similar to *Custom Components*), which we call [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
+O [componente Button]({{< ref path="api/components/ui/button.md" >}}) possui um atributo chamado `onPress` que pode receber uma lista de ações, as quais só serão executadas quando o botão for pressionado. Você pode ver todas as ações padrão do Beagle na [seção Actions]({{< ref path="api/actions/_index.md" >}}). Mas também é possível criar suas próprias ações (um processo semelhante a *Custom Componentes*), que chamamos de [Custom Actions]({{< ref path="resources/customization/_index.md" >}}).
 
 Esse exemplo usa uma [ação Alert]({{< ref path="api/actions/alert.md" >}}), o que resulta na exibição de um componente de alerta quando alguém toca o botão. Você pode fazer isso no *Playground* e ver você mesmo.
 


### PR DESCRIPTION
This PR is related to the **first page of our documentation**, which is pretty important since it's our users first experience with it

## Current Problems

1. Content is being declared in an abstract way, without examples or concrete explanations, and with repeated concepts

> Examples: 
> 
> - _"The tool works as a facilitator of BFF (Backend For Frontend). This means that Beagle, from a library of components defined in the Design System of the Android, iOS or Web application, makes the visual and behavioral change of them by returning a JSON file that indicates what and where each component should be rendered and which the action they are going to perform."_
> - _"The reason Beagle is able to make this frontend change from the backend is because its architecture is structured in Server-Driven UI, where BFF builds the data, components and actions present on the screen in a declarative way, and forwards them in a JSON format, while the front-end deserializes it, renders the visual components natively in addition to executing and assigning the actions present in each of them."_
> - _"More flexibility at work, specially among developers and UI/UX designers when it’s necessary to make specific changes."_

2. It's hard to find throughout our documentation (or maybe not present at all), a simple real example of Beagle and its core concepts

1. It doesn't use Playground, which is an awesome tool we made, and a great way to quickly experiment with Beagle APIs

1. IMHO overall it doesn't help users understand __how__ Beagle actually works, and so doesn't seem really focus on developers

1. Lack of links to other sections of our documentation

## Proposal

To handle these problems, I propose we completely change our first page so it can have the following characteristics:

1. At the start, be clear about what are the most important "business outcomes" of using Beagle

1. Change our approach to use a simple and concrete example inside Playground, that way, we can illustrate Beagle's core concepts like Components, Style, and Actions

1. Be focused on developers, so we should show how things actually work and give links to other pages if they want to learn more
