### PR TITLE
fix: flutter baseUrl examples

### DIFF
--- a/content/en/flutter/customization/configuration.md
+++ b/content/en/flutter/customization/configuration.md
@@ -47,14 +47,14 @@ enum BeagleEnvironment {
 ### 2. baseUrl
 It informs the base URL used on Beagle in the application.
 
-The requests made by `BeagleWidget` and navigation actions uses the `baseUrl` property to build their paths. The default is empty string. In the example below, the resulting request will be `http://yourBffBaseUrl.io/test`:
+The requests made by `BeagleWidget` and navigation actions uses the `baseUrl` property to build their paths. The default is empty string. In the example below, the resulting request will be `https://usebeagle.io/start/welcome`:
 ```dart
 BeagleSdk.init(
-  baseUrl: 'http://yourBffBaseUrl.io',
+  baseUrl: 'https://usebeagle.io/start',
 );
 
 BeagleWidget(
-  screenRequest: BeagleScreenRequest('test'),
+  screenRequest: BeagleScreenRequest('welcome'),
 );
 ```
 

--- a/content/en/flutter/customization/localhost.md
+++ b/content/en/flutter/customization/localhost.md
@@ -8,7 +8,7 @@ description: >-
 ---
 
 ## Running a backend in the localhost
-In the previous steps, the `baseUrl` used was `http://yourBffBaseUrl.io`, but this is just an example and you will need to replace this address by your own backend.
+In the previous steps, the `baseUrl` used was `https://usebeagle.io/start`, but this is just an example and you will need to replace this address by your own backend.
 
 ### Making HTTP requests
 By default, both Android and iOS will make only HTTPS (secured) requests. To change this behavior, follow the steps below:

--- a/content/en/flutter/getting-started.md
+++ b/content/en/flutter/getting-started.md
@@ -42,7 +42,7 @@ import 'package:beagle_components/beagle_components.dart';
 
 void main() {
   BeagleSdk.init(
-    baseUrl: 'http://yourBffBaseUrl.io',
+    baseUrl: 'https://usebeagle.io/start',
     components: defaultComponents,
   );
   // runApp();
@@ -60,7 +60,7 @@ import 'package:flutter/material.dart';
 
 void main() {
   BeagleSdk.init(
-    baseUrl: 'http://yourBffBaseUrl.io',
+    baseUrl: 'https://usebeagle.io/start',
     components: defaultComponents,
   );
   runApp(const BeagleSampleApp());

--- a/content/pt/flutter/customization/configuration.md
+++ b/content/pt/flutter/customization/configuration.md
@@ -44,15 +44,15 @@ enum BeagleEnvironment {
 ### 2. baseUrl
 Informa a URL base usada no Beagle na aplicação.
 
-As requisições feitas pelo `BeagleWidget` e ações de navegação usam a propriedade `baseUrl` para montar seus paths. O padrão é uma string vazia. No exemplo abaixo, a request resultante vai ser `http://yourBffBaseUrl.io/test`:
+As requisições feitas pelo `BeagleWidget` e ações de navegação usam a propriedade `baseUrl` para montar seus paths. O padrão é uma string vazia. No exemplo abaixo, a request resultante vai ser `https://usebeagle.io/start/welcome`:
 
 ```dart
 BeagleSdk.init(
-  baseUrl: 'http://yourBffBaseUrl.io',
+  baseUrl: 'https://usebeagle.io/start',
 );
 
 BeagleWidget(
-  screenRequest: BeagleScreenRequest('test'),
+  screenRequest: BeagleScreenRequest('welcome'),
 );
 ```
 

--- a/content/pt/flutter/customization/localhost.md
+++ b/content/pt/flutter/customization/localhost.md
@@ -8,14 +8,14 @@ description: >-
 ---
 
 ## Rodando um backend no localhost
-Nos passos anteriores, a `baseUrl` usada foi `http://yourBffBaseUrl.io`, mas isso é apenas um exemplo e você vai precisar trocá-la pelo endereço do seu backend.
+Nos passos anteriores, a `baseUrl` usada foi `https://usebeagle.io/start`, mas isso é apenas um exemplo e você vai precisar trocá-la pelo endereço do seu backend.
 
 ### Fazendo requisições HTTP
 Por padrão, ambos Android e iOS vão fazer somente requisições HTTPS (seguras). Para mudar esse comportamento, siga os passos abaixo:
 
 #### Android
-1. Abra `android / app / src / main / AndroidManifest.xml`
-2. Coloque a regra `android: usesCleartextTraffic =" true "` na tag `<application>`:
+1. Abra `android/app/src/main/AndroidManifest.xml`
+2. Coloque a regra `android:usesCleartextTraffic="true"` na tag `<application>`:
 
 ```xml
 <application

--- a/content/pt/flutter/getting-started.md
+++ b/content/pt/flutter/getting-started.md
@@ -37,7 +37,7 @@ import 'package:beagle_components/beagle_components.dart';
 
 void main() {
   BeagleSdk.init(
-    baseUrl: 'http://suaBffUrlBase.io',
+    baseUrl: 'https://usebeagle.io/start',
     components: defaultComponents,
   );
   // runApp();
@@ -55,7 +55,7 @@ import 'package:flutter/material.dart';
 
 void main() {
   BeagleSdk.init(
-    baseUrl: 'http://suaBffUrlBase.io',
+    baseUrl: 'https://usebeagle.io/start',
     components: defaultComponents,
   );
   runApp(const BeagleSampleApp());


### PR DESCRIPTION
This PR changes the fake baseUrl used in flutter examples to a valid endpoint.