### PR TITLE
Adds exclude flag to aws sync command

### DIFF
--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -45,6 +45,6 @@ jobs:
           BASE_URL: https://docs-beta.usebeagle.io
 
       - name: S3 upload (latest version)
-        run: aws s3 sync --acl public-read --follow-symlinks public s3://$AWS_S3_BUCKET --delete
+        run: aws s3 sync --acl public-read --follow-symlinks public s3://$AWS_S3_BUCKET --delete --exclude "c4model/*"
         env:
           AWS_S3_BUCKET: ${{ env.BEAGLE_DOCS_AWS_AWS_DOCS_BETA_BUCKET }}

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -1,7 +1,7 @@
 name: BETA UPLOAD
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 jobs:
@@ -45,6 +45,6 @@ jobs:
           BASE_URL: https://docs-beta.usebeagle.io
 
       - name: S3 upload (latest version)
-        run: aws s3 sync --acl public-read --follow-symlinks public s3://$AWS_S3_BUCKET --delete --exclude "c4model/*"
+        run: aws s3 sync --acl public-read --follow-symlinks public s3://$AWS_S3_BUCKET --exclude "c4model/*" --delete
         env:
           AWS_S3_BUCKET: ${{ env.BEAGLE_DOCS_AWS_AWS_DOCS_BETA_BUCKET }}

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -1,7 +1,7 @@
 name: BETA UPLOAD
 
 on:
-  pull_request:
+  push:
     branches: [main]
 
 jobs:


### PR DESCRIPTION
### What's new

 - Adds the --exlude flag in the aws sync command to try avoiding the deletion of the c4model folder

Signed-off-by: Hector Custódio <hector.custodio@zup.com.br>

