### PR TITLE
Updates beta upload file

### DIFF
--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -12,22 +12,12 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-
-      - name: Read secrets from AWS Secrets Manager into environment variables
-        uses: abhilash1in/aws-secrets-manager-action@v1.0.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-          secrets: |
-            beagle/docs/aws
-          parse-json: true
           
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_DOCS_BETA }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DOCS_BETA}}
           aws-region: sa-east-1
 
       - name: Setup Hugo
@@ -47,4 +37,4 @@ jobs:
       - name: S3 upload (latest version)
         run: aws s3 sync --acl public-read --follow-symlinks public s3://$AWS_S3_BUCKET --exclude="c4model/*" --delete
         env:
-          AWS_S3_BUCKET: ${{ env.BEAGLE_DOCS_AWS_AWS_DOCS_BETA_BUCKET }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_DOCS_BETA_BUCKET_NAME }}


### PR DESCRIPTION
Signed-off-by: Hector Custódio <hector.custodio@zup.com.br>

## What's new?
  - Added new environment keys for beta upload

## What's changed?
  - For security reasons now the bucket for beta release is no longer public so a new user has been created with new credentials.