### PR TITLE
Feature/updates beta upload

### DIFF
--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -35,5 +35,4 @@ jobs:
           BASE_URL: https://docs-beta.usebeagle.io
 
       - name: S3 upload (latest version)
-      
         run: aws s3 sync --acl public-read --follow-symlinks public s3://${{ secrets.AWS_DOCS_BETA_BUCKET_NAME }} --exclude="c4model/*" --delete

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -1,7 +1,7 @@
 name: BETA UPLOAD
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 jobs:
@@ -35,6 +35,4 @@ jobs:
           BASE_URL: https://docs-beta.usebeagle.io
 
       - name: S3 upload (latest version)
-        run: aws s3 sync --acl public-read --follow-symlinks public s3://$AWS_S3_BUCKET --exclude="c4model/*" --delete
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_DOCS_BETA_BUCKET_NAME }}
+        run: aws s3 sync --acl public-read --follow-symlinks public s3://${{ secrets.AWS_DOCS_BETA_BUCKET_NAME }} --exclude="c4model/*" --delete

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -1,7 +1,7 @@
 name: BETA UPLOAD
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -20,6 +20,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_DOCS_BETA }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DOCS_BETA}}
           aws-region: sa-east-1
+          role-to-assume: ${{secrets.AWS_BETA_ROLE_TO_ASSUME}}
+          role-session-name: BetaBeagleDocsPublish
+          role-skip-session-tagging: true
+          role-duration-seconds: 1200
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -1,7 +1,7 @@
 name: BETA UPLOAD
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -40,4 +40,4 @@ jobs:
           BASE_URL: https://docs-beta.usebeagle.io
 
       - name: S3 upload (latest version)
-        run: aws s3 sync --acl public-read --follow-symlinks public s3://${{ secrets.AWS_DOCS_BETA_BUCKET_NAME }} --exclude="c4model/*" --delete
+        run: aws s3 sync --acl public-read --follow-symlinks public s3://docs-beta.usebeagle.io --exclude="c4model/*" --delete

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -40,4 +40,4 @@ jobs:
           BASE_URL: https://docs-beta.usebeagle.io
 
       - name: S3 upload (latest version)
-        run: aws s3 sync --acl public-read --follow-symlinks public s3://docs-beta.usebeagle.io --exclude="c4model/*" --delete
+        run: aws s3 sync --follow-symlinks public s3://docs-beta.usebeagle.io --exclude="c4model/*" --delete

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -2,7 +2,8 @@ name: BETA UPLOAD
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   deploy:
@@ -12,7 +13,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -23,7 +24,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.78.1'
+          hugo-version: "0.78.1"
           extended: true
 
       - name: Installing Dependencies

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -1,7 +1,7 @@
 name: BETA UPLOAD
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 
@@ -17,8 +17,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_DOCS_BETA }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DOCS_BETA}}
+          aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_DOCS_BETA }}
+          aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY_DOCS_BETA}}
           aws-region: sa-east-1
           role-to-assume: ${{secrets.AWS_BETA_ROLE_TO_ASSUME}}
           role-session-name: BetaBeagleDocsPublish
@@ -40,4 +40,4 @@ jobs:
           BASE_URL: https://docs-beta.usebeagle.io
 
       - name: S3 upload (latest version)
-        run: aws s3 sync --follow-symlinks public s3://docs-beta.usebeagle.io --exclude="c4model/*" --delete
+        run: aws s3 sync --follow-symlinks public s3://${{secrets.AWS_DOCS_BETA_BUCKET_NAME}} --exclude="c4model/*" --delete

--- a/.github/workflows/beta-upload.yml
+++ b/.github/workflows/beta-upload.yml
@@ -12,22 +12,12 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-
-      - name: Read secrets from AWS Secrets Manager into environment variables
-        uses: abhilash1in/aws-secrets-manager-action@v1.0.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-          secrets: |
-            beagle/docs/aws
-          parse-json: true
           
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_DOCS_BETA }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DOCS_BETA}}
           aws-region: sa-east-1
 
       - name: Setup Hugo
@@ -47,4 +37,4 @@ jobs:
       - name: S3 upload (latest version)
         run: aws s3 sync --acl public-read --follow-symlinks public s3://$AWS_S3_BUCKET --exclude="c4model/*" --delete
         env:
-          AWS_S3_BUCKET: ${{ env.BEAGLE_DOCS_AWS_AWS_DOCS_BETA_BUCKET }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_DOCS_BETA_BUCKET_NAME }}


### PR DESCRIPTION
What's new
 - Docs beta bucket is no longer public so I had to change the upload method to assume role instead os acl public. Two new secrets were used the bucket name and the role that gives access to the role.