### PR TITLE
Flutter - Adds Portuguese translation for layout folder

### DIFF
--- a/content/en/flutter/layout/theme.md
+++ b/content/en/flutter/layout/theme.md
@@ -18,10 +18,26 @@ A theme is a set of styles that can be referenced by the property `styleId` of t
 
 The local image resources are strings with the paths to every image that can be accessed by the server driven view with the parameter `mobileId` of the Image component. If an image comes with the `mobileId` "logo", for instance, it would use the image path returned by `beagleTheme.image('logo')`.
 
-# How to create and setup a BeagleTheme?
-It's simple! You just need to:
+## How to use the BeagleTheme?
+
+The BeagleTheme is not a feature of the core Beagle library, but instead, it's from the package beagle_components. For this reason, differently than most configuration options, it doesn't do into the BeagleService. The BeagleTheme must be provided to the default components via the widget `BeagleThemeProvider`.
+
+The `BeagleThemeProvider` must wrap the application to prevent cases where a navigation would make it unavailable. See the example below:
+
 1. Create a class that implements the `BeagleTheme` interface;
 2. Provide an instance of the class to the `BeagleThemeProvider`, that should wrap your application.
+
+```dart
+void main() {
+  runApp(BeagleProvider(
+    beagle: beagleService,
+    child: BeagleThemeProvider(
+      theme: MyTheme(),
+      child: MyApp()
+    ),
+  ));
+}
+```
 
 ## Local images
 The method `image` receives the image id that comes from the JSON (`mobileId`) and returns the corresponding local image asset path. Check out the following example:
@@ -88,22 +104,5 @@ class MyTheme extends BeagleTheme {
   }
 
   // ...
-}
-```
-
-## How to use the BeagleTheme?
-The BeagleTheme is not a feature of the core Beagle library, but instead, it's from the package beagle_components. For this reason, differently than most configuration options, it doesn't do into the BeagleService. The BeagleTheme must be provided to the default components via the widget `BeagleThemeProvider`.
-
-The `BeagleThemeProvider` must wrap the application to prevent cases where a navigation would make it unavailable. See the example below:
-
-```dart
-void main() {
-  runApp(BeagleProvider(
-    beagle: beagleService,
-    child: BeagleThemeProvider(
-      theme: MyTheme(),
-      child: MyApp()
-    ),
-  ));
 }
 ```

--- a/content/pt/flutter/layout/_index.md
+++ b/content/pt/flutter/layout/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Layout
 weight: 1
-description: In this section, you will learn how to manage layout and appearance in Beagle Flutter.
+description: Nesta seção você aprende como gerenciar e manipular o layout e aparência de componentes no Beagle Flutter.
 ---

--- a/content/pt/flutter/layout/styles.md
+++ b/content/pt/flutter/layout/styles.md
@@ -93,7 +93,7 @@ class _ButtonBuilder extends ComponentBuilder {
 
 # Criando seus próprios containers
 
-Através do pacto beagle_components, a biblioteca fornce um componente muito importante chamado `Container`, O container é responsável por manter e organizar multiplos componentes de acordo com as propriedades providas do flex (`style.flex`).
+Através do pacote beagle_components, a biblioteca fornece um componente muito importante chamado `Container`, O container é responsável por manter e organizar multiplos componentes de acordo com as propriedades do flex (`style.flex`) providas.
 
 Se você precisar criar um novo componente que respeite todas as propriedade de `style.flex`, é preciso extender a classe `Styled`. Isso é útil para criar um componente Card, por exemplo:
 

--- a/content/pt/flutter/layout/styles.md
+++ b/content/pt/flutter/layout/styles.md
@@ -70,7 +70,7 @@ Alguns widgets tratam seus próprios estilos, por exemplo, adicionar "wrappers" 
 
 Para desabilitar o padding e decoration automáticos, mas manter todos os outros estilos, podemos implementar um método `getStyleConfig` do `ComponentBuilder` e retornar a configuração onde `` tem o valor de "true" mas `shouldDecorate` tem o valor de "false"
 
-Basta então passá-lo para o widget através do `ComponentBuilder`. Veja no trecho de código abaixo:
+Basta então passá-lo para o widget através do `ComponentBuilder`. Veja como no trecho de código abaixo:
 
 ```dart
 class _ButtonBuilder extends ComponentBuilder {

--- a/content/pt/flutter/layout/styles.md
+++ b/content/pt/flutter/layout/styles.md
@@ -212,7 +212,7 @@ class _ContainerBuilder extends ComponentBuilder {
 }
 ```
 
-Acima está um exemplo de como poderíamos ignorar o motor padrão de layout do Beagle e usar o nosso customizado, apenas expondo alguns componentes de layout do Flutter.
+Acima temos um exemplo de como poderíamos ignorar o motor padrão de layout do Beagle e usar o nosso customizado, apenas expondo alguns componentes de layout do Flutter.
 
 Para usar diferentes motores de layout, a primeira coisa que deve ser feita é desabilitar o moto padrão de layout do Beagle Flutter. Para isso, basta apenas mudar a opção `enableStyles` para o valor "false". mas tenha cuidado pois a maioria dos componentes padrão não funcionarão mais.
 

--- a/content/pt/flutter/layout/styles.md
+++ b/content/pt/flutter/layout/styles.md
@@ -66,7 +66,7 @@ class MyComponentBuilder extends ComponentBuilder {
 
 # Controlando "padding" e "decoration"
 
-Alguns widgets precisam eles mesmos tratarem seus estilos, por exemplo, adicionar "wrappers" não funciona. Veja o caso do botão, como usamos um widget do tipo `ElevatedButton`, adicionar "background color", "borders" e "padding" ao "wrapper" não vai funcionar. Ao invés disso, um objecto do tipo `ButtonStyle` deve ser criado baseado no estilo desejado e então passado ao `ElevatedButton`. Precisamos também desabilitar o comportamento padrão para padding e decorations ("backgroundcolor" e "border")
+Alguns widgets tratam seus próprios estilos, por exemplo, adicionar "wrappers" não funciona. Veja o caso do botão, como usamos um widget do tipo `ElevatedButton`, adicionar "background color", "borders" e "padding" ao "wrapper" não vai funcionar. Ao invés disso, um objecto do tipo `ButtonStyle` deve ser criado baseado no estilo desejado e então passado ao `ElevatedButton`. Precisamos também desabilitar o comportamento padrão para padding e decorations ("backgroundcolor" e "border")
 
 Para desabilitar o padding e decoration automáticos, mas manter todos os outros estilos, podemos implementar um método `getStyleConfig` do `ComponentBuilder` e retornar a configuração onde `` tem o valor de "true" mas `shouldDecorate` tem o valor de "false"
 

--- a/content/pt/flutter/layout/styles.md
+++ b/content/pt/flutter/layout/styles.md
@@ -130,7 +130,7 @@ Uma linguagem de estilo que funciona para todas as plataformas foi muito importa
 
 O Beagle Flutter é fornecido com o mecanismo de layout usado por todas as bibliotecas de interface do usuário do Beagle, portanto, ao usar nossos componentes padrão, a propriedade "style" pode ser usada e funciona. Dessa forma, é mais fácil reproduzir os exemplos, pois eles não são específicos da plataforma.
 
-Embora os estilos Beagle funcionem na maioria das vezes, infelizmente [eles têm alguns problemas](https://gist.github.com/Tiagoperes/12f786e06ad80752afacaf80bc49bcf9). Além disso, se você for usar apenas o Flutter para desenvolver o aplicativo e a plataforma não for realmente um problema, pode ser mais fácil se adaptar a um mecanismo de layout no backend que funcione mais como o próprio Flutter.
+Embora os estilos Beagle funcionem na maioria das vezes, infelizmente, [alguns ajustes ainda são necessários](https://gist.github.com/Tiagoperes/12f786e06ad80752afacaf80bc49bcf9). Além disso, se você for usar apenas o Flutter para desenvolver o aplicativo e a plataforma não for realmente um problema, pode ser mais fácil se adaptar a um mecanismo de layout no backend que funcione mais como o próprio Flutter.
 
 Em vez de usar "style", podemos expor os widgets de layout do Flutter como componentes orientados a servidor. Veja os exemplos abaixo:
 

--- a/content/pt/flutter/layout/styles.md
+++ b/content/pt/flutter/layout/styles.md
@@ -53,7 +53,7 @@ class MyComponentBuilder extends ComponentBuilder {
 }
 ```
 
-Por padrão, componentes com estilo desabilitado expandem-se para preencher todo o espaço disponível. Para desabilitar este comportamento, você pode alterar a propriedade `shoudExpand` para falso. Utilize está funcionalidade com cuidado pois ela pode gerar erros de layout no Flutter.
+Por padrão, componentes sem um estilo declarado expandem-se para preencher todo o espaço disponível. Para desabilitar este comportamento, você pode alterar a propriedade `shoudExpand` para falso. Utilize está funcionalidade com cuidado pois ela pode gerar erros de layout no Flutter.
 
 ```dart
 class MyComponentBuilder extends ComponentBuilder {

--- a/content/pt/flutter/layout/styles.md
+++ b/content/pt/flutter/layout/styles.md
@@ -2,17 +2,18 @@
 title: Styles
 weight: 3
 description: >-
-  In this section, you will find out how to manage styles in Beagle Flutter.
+  Nesta seção, você aprende como gerenciar os estilos no Beagle Flutter.
 ---
 
 ---
 
 {{% alert color="warning" %}}
-Attention: this article talks about the property `style`. despite the similar name, `styleId` and `style` are very different properties. While the latest uses a well defined set of styling properties set by the backend and applies to every component, the first is only a string and works for specific components of the package beagle_components. If you want to learn how to set up the style ids instead, go to [this page]({{< ref path="/flutter/layout/theme" lang="en" >}}).
+Atenção: este artigo explica a propriedade `style`. mesmo com nomes parecidos o `style` e `styleId` são propriedades bem diferentes. O styleId funciona em componentes específicos através de uma configuração feita nos componentes do pacote beagle_components. Aprenda mais sobre o `styleId` na seção [Beagle Theme]({{< ref path="/flutter/layout/theme" lang="en" >}}).
 {{% /alert %}}
 
-# Introduction
-Styles are every property declared in the key `style` in the JSON representation of a component. Examples of style properties are:
+# Introdução
+
+Estilos são propriedades declaradas na chave `style` na representação JSON do componente. Alguns exemplos de estilos são:
 
 - backgroundColor
 - borderColor
@@ -21,12 +22,12 @@ Styles are every property declared in the key `style` in the JSON representation
 - margin
 - flex
 
-Any component can receive a style. In Beagle WEB this is implemented via CSS and in both Android and iOS we used the Facebook library: [Yoga](https://yogalayout.com/). For Flutter we interpreted each styling property as its Flutter equivalent widget. To read more details of this implementation, check our [deep dive article](https://gist.github.com/Tiagoperes/12f786e06ad80752afacaf80bc49bcf9).
+Qualquer componente pode receber um estilo, no Beagle WEB essa implementação é feita com CSS, para Android e iOS é usada a biblioteca do Facebook [Yoga](https://yogalayout.com/). No Flutter cada propriedade é traduzida para seu widget equivalente em Flutter. Para entender melhor da uma olhada neste artigo [Beagle Flutter Theme - Saiba mais](https://gist.github.com/Tiagoperes/12f786e06ad80752afacaf80bc49bcf9).
 
-To check the full list of style properties, click [here]({{< ref path="/api/style" lang="en" >}}).
+Veja a lista completa de propriedades de estilo, [aqui]({{< ref path="/api/style" lang="pt" >}}).
 
-# Missing Style properties
-Although we have support for most of the Beagle style properties, we couldn't implement them all yet. Check below a list with all the properties that still need to be worked into Beagle Flutter:
+# Propriedades não implementadas
+Embora tenhamos suporte para a maioria das propriedades de estilo do Beagle, não foi possível implementar todas ainda. Veja abaixo a lista de propriedades que ainda precisam ser desenvolvidas:
 
 - flex.basis;
 - flex.grow;
@@ -38,10 +39,10 @@ Although we have support for most of the Beagle style properties, we couldn't im
 - The values of start and end for margin and padding;
 - positions can only have `REAL` values, not `PERCENT`.
 
-It is important to notice that although `flex.alignItems` is fully implemented, the default value for it in Flutter is `start` instead of `stretch`. For more more information on decisions like this, we refer to the [deep dive article](https://gist.github.com/Tiagoperes/12f786e06ad80752afacaf80bc49bcf9).
+Note aqui, que embora `flex.alignItems` esteja totalmente implementada, o valor padrão para Flutter é `start` ao invés de `stretch`. Para entender melhor este funcionamente, [veja o artigo](https://gist.github.com/Tiagoperes/12f786e06ad80752afacaf80bc49bcf9).
 
-# Disabling style for specific components
-Beagle adds styles to components by wrapping it in widgets like Flex, Flexible, Stack, Positioned and Container. Some widgets shouldn't receive a style and wrapping them under these components might not be desirable. To disable styling for a component, in the ComponentBuilder, you must overwrite the method `getStyleConfig` and return a config where `enabled` is false.
+# Desabilitando estilos para componentes específicos
+O Beagle adiciona estilos em componentes ao envolver cada um deles em um widget como Flex, Flexible, Stack, Positioned e Container. Alguns widgets talvez não precisam ou não possam receber estilos e este comportamento se torna indesejável. Para desabilitar a estilização em um componente, no ComponentBuilber é necessário sobrescrever o método `getStyleConfig` e retornar uma configuração com o valor de `enabled` falso.
 
 ```dart
 class MyComponentBuilder extends ComponentBuilder {
@@ -52,7 +53,7 @@ class MyComponentBuilder extends ComponentBuilder {
 }
 ```
 
-By default, unstyled components expand to fill all the available space. To disable this behavior, you can also set `shouldExpand` to false. But be careful, by disabling this you can end up with layout errors in Flutter.
+Por padrão, componentes com estilo desabilitado expandem-se para preencher todo o espaço disponível. Para desabilitar este comportamento, você pode alterar a propriedade `shoudExpand` para falso. Utilize está funcionalidade com cuidado pois ela pode gerar erros de layout no Flutter.
 
 ```dart
 class MyComponentBuilder extends ComponentBuilder {
@@ -63,12 +64,13 @@ class MyComponentBuilder extends ComponentBuilder {
 }
 ```
 
-# Taking control of padding and decoration
-Some widgets need to deal with the styles themselves, i.e., adding wrappers won't help. Take the button for instance, since we use an ElevatedButton, adding background color, borders and padding to the wrapper won't render the desired button. Instead of creating these wrappers, a ButtonStyle object must be created based on the style and passed to the ElevatedButton. At the same time, we must disable the default behavior for padding and decorations (background color and border).
+# Controlando "padding" e "decoration"
 
-To disable the automatic addition of padding and decorations, but keep all other styling properties, you can implement the method `getStyleConfig` of the ComponentBuilder and return a configuration where `enabled` is true but `shouldDecorate` is false.
+Alguns widgets precisam eles mesmos tratarem seus estilos, por exemplo, adicionar "wrappers" não funciona. Veja o caso do botão, como usamos um widget do tipo `ElevatedButton`, adicionar "background color", "borders" e "padding" ao "wrapper" não vai funcionar. Ao invés disso, um objecto do tipo `ButtonStyle` deve ser criado baseado no estilo desejado e então passado ao `ElevatedButton`. Precisamos também desabilitar o comportamento padrão para padding e decorations ("backgroundcolor" e "border")
 
-To treat the style from within the widget, you can pass it to the widget from the ComponentBuilder. See the example below:
+Para desabilitar o padding e decoration automáticos, mas manter todos os outros estilos, podemos implementar um método `getStyleConfig` do `ComponentBuilder` e retornar a configuração onde `` tem o valor de "true" mas `shouldDecorate` tem o valor de "false"
+
+Basta então passá-lo para o widget através do `ComponentBuilder`. Veja no trecho de código abaixo:
 
 ```dart
 class _ButtonBuilder extends ComponentBuilder {
@@ -87,12 +89,13 @@ class _ButtonBuilder extends ComponentBuilder {
 }}
 ```
 
-`style` is of type `BeagleStyle`.
+`style` é do tipo `BeagleStyle`.
 
-# Creating your own containers
-Through the package beagle_components, Beagle ships with a very important component called `Container`. The container is responsible for holding multiple components and organizing them according to the provided flex properties (`style.flex`).
+# Criando seus próprios containers
 
-If you need to create a new container that respects all the properties from `style.flex`, you need to extend the class `Styled`. This can be useful for creating a Card component, for example.
+Através do pacto beagle_components, a biblioteca fornce um componente muito importante chamado `Container`, O container é responsável por manter e organizar multiplos componentes de acordo com as propriedades providas do flex (`style.flex`).
+
+Se você precisar criar um novo componente que respeite todas as propriedade de `style.flex`, é preciso extender a classe `Styled`. Isso é útil para criar um componente Card, por exemplo:
 
 ```dart
 class Card extends Styled {
@@ -115,20 +118,21 @@ class Card extends Styled {
 }
 ```
 
-`Styled` is a `StatelessWidget`. You can use the classes `StatefulStyled` and `StyledState` for creating Stateful components that act like layout containers.
+`Styled` é um `StatelessWidget`. Você pode usar as classes `StatefulStyled` e `StyledState` para criar componentes do tipo "Stateful" que funcionam como containers de layout.
 
-When extending classes and also using mixins, you can end up overshadowing some methods of the super-class. If this happens and you need to make a call to `StyledState`, instead of using `super.build`, `super.initState` and `super.didUpdateWidget`, you can use `buildStyled`, `initStyled` and `updateStyled`.
+Ao estender classes e usar mixins, você pode acabar desabilitando alguns métodos da super-classe. Se isso acontecer e você precisar chamar `StyledState`, prefira usar `super.build`, `super.initState` e `super.didUpdateWidget`, você pode usar `buildStyled`, `initStyled` e `updateStyled`.
 
-# A different approach to styles in Beagle Flutter
-Beagle defines a set of properties to manipulate the style and layout of a component. These properties are the same across all platforms (iOS, Android, Web and Flutter), i.e. the json generated by the backend is compatible with any of these platforms.
+# Uma abordagem diferente para estilos no Beagle Flutter
 
-One style language that works for all platforms was very important for iOS, Android and Web. So, using Yoga, we implemented a set of layout features based on the Flex layout of the CSS specification. Now, if we're using Flutter, do we still need to use the same style language? Nobody is going to develop an app for iOS and Flutter, for instance, it would be crazy. Since all platforms of the application can use Flutter, the style language could be defined by Flutter itself and not Beagle, which would be simpler for developers already Familiar with the Flutter widgets.
+O Beagle define um conjunto de propriedades para manipular o estilo e o layout de um componente. Essas propriedades são as mesmas em todas as plataformas (iOS, Android, Web e Flutter), ou seja, o json gerado pelo backend é compatível com qualquer uma dessas plataformas.
 
-Beagle Flutter ships with the layout engine that is used by every Beagle UI Library, so, when using our default components, the "style" property can be used and it works. This way, it is easier to reproduce the examples, because they're not platform specific.
+Uma linguagem de estilo que funciona para todas as plataformas foi muito importante para iOS, Android e Web. Assim, usando o Yoga, implementamos um conjunto de recursos de layout com base no layout Flex da especificação CSS. Agora, se estamos usando o Flutter, ainda precisamos usar a mesma linguagem de estilo? Ninguém vai desenvolver um app para iOS e Flutter, por exemplo, seria uma loucura. Como todas as plataformas do aplicativo podem usar o Flutter, a linguagem de estilo poderia ser definida pelo próprio Flutter e não pelo Beagle, o que seria mais simples para desenvolvedores já familiarizados com os widgets do Flutter.
 
-Although the Beagle styles work for the most part, unfortunately [they do have some issues](https://gist.github.com/Tiagoperes/12f786e06ad80752afacaf80bc49bcf9). Moreover, if you're only gonna use Flutter to develop the application and the platform is not really a problem, it might be easier to adapt to a layout engine in the backend that works more like Flutter itself.
+O Beagle Flutter é fornecido com o mecanismo de layout usado por todas as bibliotecas de interface do usuário do Beagle, portanto, ao usar nossos componentes padrão, a propriedade "style" pode ser usada e funciona. Dessa forma, é mais fácil reproduzir os exemplos, pois eles não são específicos da plataforma.
 
-Instead of using "style", we can expose the Flutter layout widgets as Server Driven Components. See the examples below:
+Embora os estilos Beagle funcionem na maioria das vezes, infelizmente [eles têm alguns problemas](https://gist.github.com/Tiagoperes/12f786e06ad80752afacaf80bc49bcf9). Além disso, se você for usar apenas o Flutter para desenvolver o aplicativo e a plataforma não for realmente um problema, pode ser mais fácil se adaptar a um mecanismo de layout no backend que funcione mais como o próprio Flutter.
+
+Em vez de usar "style", podemos expor os widgets de layout do Flutter como componentes orientados a servidor. Veja os exemplos abaixo:
 
 ```dart
 final Map<String, ComponentBuilder Function()> defaultComponents = {
@@ -208,9 +212,9 @@ class _ContainerBuilder extends ComponentBuilder {
 }
 ```
 
-Above is an example of how we could ignore the Beagle default layout engine and use our own. In this case, just exposing some layout components from Flutter.
+Acima está um exemplo de como poderíamos ignorar o motor padrão de layout do Beagle e usar o nosso customizado, apenas expondo alguns componentes de layout do Flutter.
 
-For using a different layout engine, the first thing we must do is disable the default layout engine of Beagle Flutter. To do this, it's very simple, just set `enableStyles` to false in the configuration. But be aware that most of the default components will stop working.
+Para usar diferentes motores de layout, a primeira coisa que deve ser feita é desabilitar o moto padrão de layout do Beagle Flutter. Para isso, basta apenas mudar a opção `enableStyles` para o valor "false". mas tenha cuidado pois a maioria dos componentes padrão não funcionarão mais.
 
 ```dart
 final beagleService = BeagleService(

--- a/content/pt/flutter/layout/theme.md
+++ b/content/pt/flutter/layout/theme.md
@@ -2,29 +2,48 @@
 title: Beagle Theme
 weight: 3
 description: >-
- In this section, you will find information on how to create and use your own theme for the Beagle components in Flutter.
+ Aprenda nesta seção, como criar seu próprio tema customizado para os componentes Beagle Flutter.
 ---
 
 ---
 
 {{% alert color="warning" %}}
-Attention: this article talks about the `styleId`. Despite the similar name, `styleId` and `style` are very different properties. While the latest uses a well defined set of styling properties set by the backend and applies to every component, the first is only a string and works for specific components of the package beagle_components. If you want to learn how to set up the styles instead, go to [this page]({{< ref path="/flutter/layout/styles" lang="en" >}}).
+Atenção: Este artigo demonstra o uso do styleId. Mesmo com nomes parecidos o styleId e o style são propriedades bem diferentes. O style usa propriedades pré-definidas pelo Beagle, que aplica mudanças no componente específico que foi adicionada. para aprender mais sobre a propriedade style, [nesta página]({{< ref path="/flutter/layout/styles" lang="pt" >}}).
 {{% /alert %}}
 
-# What is the BeagleTheme
-The `BeagleTheme` is a configuration class for the default components of Beagle (package beagle_components). It is responsible for creating themes for the components Button, Text and Screen (navigation bar) and also for providing local image resources for the component Image.
+# O que é o BeagleTheme
 
-A theme is a set of styles that can be referenced by the property `styleId` of the component. A button that comes with the `styleId` "primary", for instance, will use the ButtonStyle returned by `beagleTheme.buttonStyle('primary')`.
+O `BeagleTheme` é uma classe de configuração para os componentes padrão do Beagle (package beagle_components). Ela é responsável por criar temas para os componentes "Button", "Text" e "Screen" (Barra de navegação) e também provê recursos de imagem local para o componente "Image".
 
-The local image resources are strings with the paths to every image that can be accessed by the server driven view with the parameter `mobileId` of the Image component. If an image comes with the `mobileId` "logo", for instance, it would use the image path returned by `beagleTheme.image('logo')`.
+Um tema é um conjunto de estilos que são acessados pela propriedade `styleId` do componente. Um botão com o `styleId` = "primary" por exemplo, vai aplicar o tema retornado pelo estilo `beagleTheme.buttonStyle('primary')`.
 
-# How to create and setup a BeagleTheme?
-It's simple! You just need to:
-1. Create a class that implements the `BeagleTheme` interface;
-2. Provide an instance of the class to the `BeagleThemeProvider`, that should wrap your application.
+Os recursos de imagem local são strings com os caminhos para cada imagem que pode ser acessadas pela `server driven view` pelo parâmetro `mobileId` do componente de Imagem. Se por exemplo uma imagem retorna com o valor de `mobileId` = "logo", o caminho da imagem será buscado em `beagleTheme.image('logo')`.
 
-## Local images
-The method `image` receives the image id that comes from the JSON (`mobileId`) and returns the corresponding local image asset path. Check out the following example:
+## Como usar o BeagleTheme?
+
+O BeagleTheme não é uma funcionalidade do "core" da biblioteca Beagle. mas sim, do pacote beagle_components. Por isso, diferente da maioria das opções ele não é configurado no BeagleService. O BeagleTheme deve ser passado aos componentes padrão atráves do widget `BeagleThemeProvider`.
+
+É essencial que o `BeagleThemeProvider` fique no nível mais alto da hierarquia de componentes para prevenir casos em que a navegação possa torná-lo indisponível.
+
+1. Crie uma classe que implemente a interface `BeagleTheme`
+2. Adicione uma instancia da classe criado ao `BeagleThemeProvider`
+
+Esses dois passos já configuram o BeagleTheme da sua aplicação
+
+```dart
+void main() {
+  runApp(BeagleProvider(
+    beagle: beagleService,
+    child: BeagleThemeProvider(
+      theme: MyTheme(),
+      child: MyApp()
+    ),
+  ));
+}
+```
+
+## Imagens locais
+O método `image` recebe um identificador da imagem que vem do JSON (`mobileId`) e retorna o caminho correspondente da imagem local em "assets". Veja o exemplo abaixo:
 
 ```dart
 class MyTheme extends BeagleTheme {
@@ -44,7 +63,7 @@ class MyTheme extends BeagleTheme {
 ```
 
 ## Button style
-The method `buttonStyle` receives the `styleId` that comes from the JSON and returns the corresponding `ButtonStyle`. Example:
+O método `buttonStyle` recebe o `styleId` que vem do JSON e retorna o estilo correspondente em `ButtonStyle`. Veja o exemplo:
 
 ```dart
 class MyTheme extends BeagleTheme {
@@ -69,7 +88,8 @@ class MyTheme extends BeagleTheme {
 ```
 
 ## Text style
-The method `textStyle` receives the `styleId` that comes from the JSON and returns the corresponding `TextStyle`. Check out an implementation:
+
+O método `textStyle` recebe o `styleId` que vem do JSON e retorna o valor correspondente em `TextStyle`. Veja o exemplo:
 
 ```dart
 class MyTheme extends BeagleTheme {
@@ -88,22 +108,5 @@ class MyTheme extends BeagleTheme {
   }
 
   // ...
-}
-```
-
-## How to use the BeagleTheme?
-The BeagleTheme is not a feature of the core Beagle library, but instead, it's from the package beagle_components. For this reason, differently than most configuration options, it doesn't do into the BeagleService. The BeagleTheme must be provided to the default components via the widget `BeagleThemeProvider`.
-
-The `BeagleThemeProvider` must wrap the application to prevent cases where a navigation would make it unavailable. See the example below:
-
-```dart
-void main() {
-  runApp(BeagleProvider(
-    beagle: beagleService,
-    child: BeagleThemeProvider(
-      theme: MyTheme(),
-      child: MyApp()
-    ),
-  ));
 }
 ```


### PR DESCRIPTION
Signed-off-by: Hector Custódio <hector.custodio@zup.com.br>

### What's new

 - Translates Flutter documentation for Beagle's 2.0 version
    - layout folder